### PR TITLE
Revert "ruby-prepare workflow ignore expired cert (workaround)"

### DIFF
--- a/.github/workflows/prepare-rake.yml
+++ b/.github/workflows/prepare-rake.yml
@@ -54,10 +54,10 @@ jobs:
 
       - id: matrix
         run: |
-          value="$(curl -L -k https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/ruby-matrix.json)"
+          value="$(curl -L https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/ruby-matrix.json)"
           echo "value=$(echo ${value} | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
       - id: config
         run: |
-          value="$(curl -L -k https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/config.json | jq .ruby.version -r)"
+          value="$(curl -L https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/config.json | jq .ruby.version -r)"
           echo "default_ruby_version=${value}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Merge this to remove workaround ASAP

Original issue:

```
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

https://github.com/fontist/extract_ttc/actions/runs/4515208163/jobs/7952357426#step:6:11

Maybe related to https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/