### PR TITLE
Disable documents test on processors metanorma-*

### DIFF
--- a/.github/workflows/mn-processor-rake.yml
+++ b/.github/workflows/mn-processor-rake.yml
@@ -86,6 +86,12 @@ jobs:
         env:
           FLAVOR: ${{ steps.flavor.outputs.value }}
         run: |
+          # remove after 'cimas sync'
+          if [ "${FLAVOR}" != "cli" ]; then
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           if [ ! -f ${{ inputs.samples-matrix-json-file }} ]; then
             if curl --fail --head "https://github.com/metanorma/mn-samples-${FLAVOR}"; then
               echo "{ \"flavor\": [ { \"id\": \"${FLAVOR}\", \"experimental\": false } ] }" > ${{ inputs.samples-matrix-json-file }}
@@ -104,6 +110,11 @@ jobs:
         env:
           FLAVOR: ${{ steps.flavor.outputs.value }}
         run: |
+          # remove after 'cimas sync'
+          if [ "${FLAVOR}" != "cli" ]; then
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           if [ ! -f ${{ inputs.templates-matrix-json-file }} ]; then
             if ! wget https://raw.githubusercontent.com/metanorma/mn-templates-${FLAVOR}/master/.github/workflows/matrix.json -O ${{ inputs.templates-matrix-json-file }}; then
               echo "No ${{ inputs.templates-matrix-json-file }} or https://github.com/metanorma/mn-templates-${FLAVOR} found!"

--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -34,7 +34,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-m3aawg:
@@ -42,7 +42,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-cc:
@@ -50,7 +50,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-vg:
@@ -58,7 +58,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-ribose:
@@ -66,7 +66,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-iho:
@@ -74,7 +74,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-ieee:
@@ -82,7 +82,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-gb:
@@ -90,7 +90,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-nist:
@@ -98,7 +98,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release_github_packages.yml: gh-actions/master/release_github_packages.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-iec:
@@ -106,7 +106,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-ietf:
@@ -122,7 +122,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-iso:
@@ -130,7 +130,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-un:
@@ -138,7 +138,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-itu:
@@ -146,7 +146,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-generic:
@@ -154,7 +154,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-csa:
@@ -162,7 +162,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-bipm:
@@ -170,7 +170,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-bsi:
@@ -178,7 +178,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release_github_packages.yml: gh-actions/master/release_github_packages.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-jis:
@@ -186,7 +186,7 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake-flavor.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-document:


### PR DESCRIPTION
This PR to discuss our metanorma test approach

Recently @opoudjis asked me:

> are the samples tests in metanorma-* now redundant?
>... Just want to make sure documents aren't being tested twice

For now we do testing documents in 3 places:
1. on `metanorma-*` gem changes, we test only specific `mn-samples-*` and `mn-templates-*`
1. on `metanorma-cli` gem changes, we test subset of all our `mn-samples-*` and `mn-templates-*`, king of smoke test
1. on `mn-samples-*` and `mn-templates-*`changes

@opoudjis proposal is to remove processor tests (first row from the list above)

Pros:
- Reduce the ci time
- Simplify ci configuration

Cons:
- We will identify the issue much later in time i.e. on `metanorma-cli` run

@ronaldtse any thoughts?

P.S. If we can make development more comfortable for @opoudjis I have no objections to go with this approach
