### PR TITLE
Inkscape downgrade: from 1.3.1 to 1.3.0

### DIFF
--- a/inkscape-setup-action/action.yml
+++ b/inkscape-setup-action/action.yml
@@ -39,7 +39,7 @@ runs:
         cmds = {
           "Darwin": [ "HOMEBREW_CASK_OPTS='--no-quarantine' brew install --cask inkscape", "inkscape --version" ],
           "Windows": [
-            "choco install --no-progress -y inkscape",
+            "choco install --no-progress -y inkscape --version=1.3.0",
             "echo {}>> {}".format(win_prefix, os.environ["GITHUB_PATH"]),
             "\"{}\\inkscape\" --version".format(win_prefix)
           ],


### PR DESCRIPTION
By some reason Inkscape version of 1.3.1 hangs on CI when trying to convert EPS/PS to other formats:
https://github.com/metanorma/vectory/actions/runs/6890504482/job/19106682845

This PR proposes to fix the version, until 1.3.2 is released in Chocolatey: https://community.chocolatey.org/packages/InkScape#versionhistory

And then see whether the issue still persists.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
