### PR TITLE
libreoffice-setup-action: Add `apt-get update`

### DIFF
--- a/libreoffice-setup-action/action.yml
+++ b/libreoffice-setup-action/action.yml
@@ -18,6 +18,7 @@ runs:
             "\"{}soffice\" --version".format(win_prefix)
           ],
           "Linux": [
+            "sudo apt-get update",
             "sudo apt-get -y --no-install-recommends install libreoffice",
             "soffice --version"
           ]


### PR DESCRIPTION
In `coradoc`, we need Libreoffice present to run our tests, due to its `w2a` component. Libreoffice is provisioned with the `libreoffice-setup-action`. Unfortunately, quite often the tests are failing due to package cache being outdated - see for instance [1]. This commit ensures that we update the package cache each time before Libreoffice install is triggered.

[1] https://github.com/metanorma/coradoc/actions/runs/10433626451/job/28897219676?pr=117

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
