### PR TITLE
fix: For Ruby 3.1, upgrade Rubygems to latest to work around Psych is…

### DIFF
--- a/.github/workflows/ruby-matrix.json
+++ b/.github/workflows/ruby-matrix.json
@@ -2,7 +2,7 @@
   "ruby": [
     {
       "version": "3.1",
-      "rubygems": "default",
+      "rubygems": "latest",
       "bundler": "default",
       "experimental": false
     },


### PR DESCRIPTION
For Ruby 3.1, upgrade Rubygems to latest to work around Psych issues.

Fixes #194.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
