### PR TITLE
Update max-parallel from 5 to 6 to match the ruby-os matrix size

### DIFF
--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -33,7 +33,7 @@ jobs:
     continue-on-error: ${{ matrix.ruby.experimental }}
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 6
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
 
     steps:


### PR DESCRIPTION
Ruby x OS matrix size is 6, so it makes sense to increase the max-parallel to match it. Especially because the last matrix item is the typically slowest ruby3.4@windows-latest

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
