### PR TITLE
feat(ci): add GitHub environment support for release protection

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -37,6 +37,11 @@ on:
         description: 'OIDC Role ID from RubyGems.org for Trusted Publishing (optional - auto-discovered if not provided)'
         required: false
         type: string
+      environment:
+        description: 'GitHub environment name for protection rules (e.g., "release" for required approvers)'
+        required: false
+        type: string
+        default: ''
     secrets:
       rubygems-api-key:
         required: false
@@ -45,6 +50,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

Add optional `environment` input to enable GitHub Environment protection rules for gem releases (e.g., required approvers, wait timers, branch restrictions).

## Background

The RubyGems Trusted Publishing guide recommends using a GitHub Environment for additional security controls:

> "We suggest using the GitHub Action Environment name 'release', which we will use in our workflow examples."

See: https://guides.rubygems.org/trusted-publishing/adding-a-publisher/

This change also completes the discussion at:
https://github.com/rubygems/rubygems.org/issues/4294#issuecomment-3815404493

## Changes

- Add `environment` input (optional, default `''`)
- Apply environment to release job

## Backward Compatibility

**This change is fully backward compatible:**
- Empty string (default) means no environment is used
- Existing workflows behave exactly as before
- Only workflows that explicitly pass `environment: "release"` will use protection rules

## Usage Example

For gems that want release protection rules:

\`\`\`yaml
jobs:
  release:
    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
    with:
      next_version: ${{ inputs.next_version }}
      environment: release  # <-- enables GitHub Environment protection
\`\`\`

## Test Plan

- [x] CI lint passes
- [x] Existing callers unaffected (backward compatible)
- [x] New callers can optionally use environment protection

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of changes completed
- [x] Backward compatibility maintained