### PR TITLE
fix: run `fontist-repo-setup` in `samples` directory

### DIFF
--- a/.github/workflows/mn-processor-rake.yml
+++ b/.github/workflows/mn-processor-rake.yml
@@ -269,6 +269,7 @@ jobs:
       with:
         private-fonts-pat: ${{ secrets.pat_token }}
         use-bundler: 'true'
+        working-directory: samples
 
     - uses: metanorma/ci/inkscape-setup-action@main
 


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


This PR ensures that `metanorma/ci/fontist-repo-setup` runs from the `samples` directory in the `mn-processor-rake` workflow so **Fontist** is configured against the `mn-samples` checkout.

fixes metanorma/metanorma-cli#403