### PR TITLE
docs: add description to private-fonts input for clarity

### DIFF
--- a/.github/workflows/inkscape-rake.yml
+++ b/.github/workflows/inkscape-rake.yml
@@ -4,8 +4,9 @@ on:
   workflow_call:
     inputs:
       private-fonts:
-        default: 'false'
+        description: 'Set to true to enable private fonts via fontist-repo-setup'
         required: false
+        default: 'false'
         type: string
     secrets:
       pat_token:

--- a/.github/workflows/sample-docker-private.yml
+++ b/.github/workflows/sample-docker-private.yml
@@ -8,8 +8,9 @@ on:
         required: false
         type: string
       private-fonts:
-        default: 'false'
+        description: 'Set to true to enable private fonts via fontist-repo-setup'
         required: false
+        default: 'false'
         type: string
       deploy-gh-pages:
         default: 'false'

--- a/.github/workflows/sample-docker.yml
+++ b/.github/workflows/sample-docker.yml
@@ -8,8 +8,9 @@ on:
         required: false
         type: string
       private-fonts:
-        default: 'false'
+        description: 'Set to true to enable private fonts via fontist-repo-setup'
         required: false
+        default: 'false'
         type: string
       deploy-gh-pages:
         default: 'true'

--- a/.github/workflows/sample-gen.yml
+++ b/.github/workflows/sample-gen.yml
@@ -4,8 +4,9 @@ on:
   workflow_call:
     inputs:
       private-fonts:
-        default: 'false'
+        description: 'Set to true to enable private fonts via fontist-repo-setup'
         required: false
+        default: 'false'
         type: string
     secrets:
       pat_token:

--- a/.github/workflows/sample-test.yml
+++ b/.github/workflows/sample-test.yml
@@ -4,8 +4,9 @@ on:
   workflow_call:
     inputs:
       private-fonts:
-        default: 'false'
+        description: 'Set to true to enable private fonts via fontist-repo-setup'
         required: false
+        default: 'false'
         type: string
     secrets:
       pat_token:


### PR DESCRIPTION
## Summary

This PR clarifies that the `private-fonts` input in reusable workflows is **optional** by adding explicit descriptions.

## Problem

A user reported that they needed to specify `private-fonts: 'false'` when calling `inkscape-rake.yml@main`, even though this should not be necessary.

## Analysis

The workflow definition was **already correct**:

```yaml
inputs:
  private-fonts:
    default: 'false'
    required: false
    type: string
```

This means:
- `required: false` - the input is NOT required
- `default: 'false'` - if not provided, it defaults to `'false'`

Callers should **NOT** need to specify `private-fonts: 'false'` when calling this workflow. The condition `inputs.private-fonts == 'true'` will correctly evaluate to `false` when the input uses its default value, and the `fontist-repo-setup` step will be skipped.

## Solution

Added explicit `description` to the `private-fonts` input in all affected workflows for clarity:

- `inkscape-rake.yml`
- `sample-gen.yml`
- `sample-test.yml`
- `sample-docker.yml`
- `sample-docker-private.yml`

## Usage

Callers can use the workflow without specifying `private-fonts`:

```yaml
jobs:
  rake:
    uses: metanorma/ci/.github/workflows/inkscape-rake.yml@main
    secrets:
      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
```

If private fonts are needed:

```yaml
jobs:
  rake:
    uses: metanorma/ci/.github/workflows/inkscape-rake.yml@main
    with:
      private-fonts: 'true'
    secrets:
      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
```

## Test plan

- [ ] Verify workflow YAML is valid (yamllint passes)
- [ ] Verify existing callers in metanorma repositories work without changes