### PR TITLE
fix(inkscape): use latest version on Windows via Chocolatey

### DIFF
--- a/inkscape-setup-action/action.yml
+++ b/inkscape-setup-action/action.yml
@@ -40,9 +40,11 @@ runs:
 
         platform_name = "Ubuntu" if os_release_dict.get("ID", None) == "ubuntu" else platform.system()
 
+        # Version pinning: macOS and Windows use latest available from package manager
+        # Ubuntu uses PPA version pattern, Linux (generic) uses specific AppImage URL
         version = {
-          "Darwin": "inkscape", # latest is 1.4.+
-          "Windows": "1.4.2",
+          "Darwin": None,  # Homebrew always installs latest
+          "Windows": None, # Chocolatey always installs latest
           "Ubuntu": "1:1.4*",
           "Linux": "https://inkscape.org/gallery/item/53678/Inkscape-e7c3feb-x86_64.AppImage"
         }.get(platform_name, None)
@@ -53,7 +55,7 @@ runs:
             "inkscape --version"
           ],
           "Windows": [
-            "choco install --no-progress -y inkscape --verbose --version {}".format(version),
+            "choco install --no-progress -y inkscape --verbose",
             "echo {}>> {}".format(win_prefix, os.environ["GITHUB_PATH"]),
             "\"{}\\inkscape\" --version".format(win_prefix)
           ],


### PR DESCRIPTION
## Summary

- Removes version pinning for Windows Inkscape installation
- Changes `choco install inkscape --version 1.4.2` to `choco install inkscape` (always latest)
- Adds documentation comments explaining version strategy per platform

## Motivation

Windows was the only platform with strict version pinning. When Inkscape 1.4.3 was released, the action failed to use it. This change ensures Windows always gets the latest stable version from Chocolatey, matching the behavior of macOS (which uses Homebrew without version pinning).

## Platform Version Strategy (After This Change)

| Platform | Strategy | Install Method |
|----------|----------|----------------|
| macOS | Always latest | Homebrew cask |
| Windows | Always latest | Chocolatey |
| Ubuntu | Pinned `1:1.4*` | apt via PPA |
| Linux (generic) | Specific AppImage | wget |

## Test Plan

- [ ] Verify action syntax is valid (yamllint passes)
- [ ] Monitor next CI run on a Windows runner to confirm Inkscape installs correctly
- [ ] Verify `inkscape --version` shows latest available Chocolatey version

🤖 Generated with [Claude Code](https://claude.com/claude-code)