### PR TITLE
feat: Add optional `Inkscape-setup` step to `generic-rake` workflow

### DIFF
--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -21,6 +21,10 @@ on:
         type: string
         default: ''
         required: false
+      setup-inkscape:
+        description: Whether to set up Inkscape for tests that require it
+        type: boolean
+        default: false
     secrets:
       pat_token:
         required: false
@@ -69,6 +73,9 @@ jobs:
 
       - if: ${{ inputs.after-setup-ruby != '' }}
         run: ${{ inputs.after-setup-ruby }}
+
+      - if: ${{ inputs.setup-inkscape }}
+        uses: metanorma/ci/inkscape-setup-action@main
 
       - run: bundle exec rake
 


### PR DESCRIPTION
This PR adds optional `inkscape-setup-action` support to the `generic-rake` workflow via the `setup-inkscape` input parameter (defaults to `false`).

This allows projects that depend on `Inkscape` to enable it when needed without affecting other projects.

required for **metanorma/metanorma-ogc#924**