### PR TITLE
feat: add shell input to generic-rake workflow

### DIFF
--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -21,6 +21,11 @@ on:
         type: string
         default: ''
         required: false
+      shell:
+        description: Shell to use for running commands
+        type: string
+        default: 'bash'
+        required: false
       setup-inkscape:
         description: Whether to set up Inkscape for tests that require it
         type: boolean
@@ -63,6 +68,7 @@ jobs:
 
       - if: ${{ inputs.before-setup-ruby != '' }}
         run: ${{ inputs.before-setup-ruby }}
+        shell: ${{ inputs.shell }}
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -73,11 +79,13 @@ jobs:
 
       - if: ${{ inputs.after-setup-ruby != '' }}
         run: ${{ inputs.after-setup-ruby }}
+        shell: ${{ inputs.shell }}
 
       - if: ${{ inputs.setup-inkscape }}
         uses: metanorma/ci/inkscape-setup-action@main
 
       - run: bundle exec rake
+        shell: ${{ inputs.shell }}
 
       # - if: needs.prepare.outputs.public == 'true' && matrix.os == 'ubuntu-latest' && matrix.ruby.version == needs.prepare.outputs.default-ruby-version
       #   uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary

Adds a `shell` input to the `generic-rake.yml` workflow to allow specifying the shell to use for running commands.

## Changes
- Added `shell` input with default value `'bash'` for cross-platform compatibility
- Applied `shell: ${{ inputs.shell }}` to:
  - `before-setup-ruby` step
  - `after-setup-ruby` step  
  - `bundle exec rake` step

## Motivation
This allows callers to specify a different shell (e.g., `pwsh` for Windows) when needed for their specific commands.

## Test plan
- [ ] Verify workflow passes with default `bash` shell
- [ ] Test with custom shell input