### PR TITLE
feat: consolidate tool-specific rake workflows into generic-rake.yml

### DIFF
--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -30,6 +30,31 @@ on:
         description: Whether to set up Inkscape for tests that require it
         type: boolean
         default: false
+      setup-tools:
+        description: 'Comma-separated list of tools to set up: inkscape, ghostscript, graphviz, libreoffice, xml2rfc'
+        type: string
+        default: ''
+        required: false
+      submodules:
+        description: 'Checkout submodules: true, false, or recursive'
+        type: string
+        default: 'recursive'
+        required: false
+      private-fonts:
+        description: 'Set to true to enable private fonts via fontist-repo-setup'
+        type: string
+        default: 'false'
+        required: false
+      private-fonts-username:
+        description: 'Username for private fonts repository'
+        type: string
+        default: 'metanorma-ci'
+        required: false
+      choco-cache:
+        description: 'Whether to set up Chocolatey cache on Windows'
+        type: boolean
+        default: false
+        required: false
     secrets:
       pat_token:
         required: false
@@ -63,7 +88,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.pat_token || github.token }}
-          submodules: 'recursive'
+          submodules: ${{ inputs.submodules }}
 
       - if: matrix.os == 'windows-latest'
         uses: actions/setup-java@v5
@@ -84,8 +109,30 @@ jobs:
       - if: ${{ inputs.after-setup-ruby != '' }}
         run: ${{ inputs.after-setup-ruby }}
 
-      - if: ${{ inputs.setup-inkscape }}
+      - if: ${{ inputs.choco-cache && runner.os == 'Windows' }}
+        uses: metanorma/ci/choco-cache-action@main
+
+      - if: inputs.setup-inkscape || contains(inputs.setup-tools, 'inkscape')
         uses: metanorma/ci/inkscape-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'ghostscript')
+        uses: metanorma/ci/ghostscript-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'graphviz')
+        uses: metanorma/ci/graphviz-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'libreoffice')
+        uses: metanorma/ci/libreoffice-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'xml2rfc')
+        uses: metanorma/ci/xml2rfc-setup-action@main
+
+      - if: inputs.private-fonts == 'true'
+        uses: metanorma/ci/fontist-repo-setup@main
+        with:
+          private-fonts-pat: ${{ secrets.pat_token }}
+          private-fonts-username: ${{ inputs.private-fonts-username }}
+          use-bundler: 'true'
 
       - run: bundle exec rake
 

--- a/cimas-config/gh-actions/graphviz/rake.yml
+++ b/cimas-config/gh-actions/graphviz/rake.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/graphviz-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: graphviz
+      submodules: true
+      choco-cache: true
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}

--- a/cimas-config/gh-actions/inkscape/rake-daily.yml
+++ b/cimas-config/gh-actions/inkscape/rake-daily.yml
@@ -10,6 +10,10 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/inkscape-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: inkscape,ghostscript
+      submodules: true
+      choco-cache: true
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}

--- a/cimas-config/gh-actions/inkscape/rake.yml
+++ b/cimas-config/gh-actions/inkscape/rake.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/inkscape-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: inkscape,ghostscript
+      submodules: true
+      choco-cache: true
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}

--- a/cimas-config/gh-actions/libreoffice/rake.yml
+++ b/cimas-config/gh-actions/libreoffice/rake.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/libreoffice-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: libreoffice
+      submodules: false
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}

--- a/cimas-config/gh-actions/xml2rfc/rake.yml
+++ b/cimas-config/gh-actions/xml2rfc/rake.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/xml2rfc-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: xml2rfc
+      submodules: false
+      choco-cache: true
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `setup-tools`, `submodules`, `private-fonts`, `private-fonts-username`, and `choco-cache` inputs to `generic-rake.yml`, enabling it to replace 4 near-identical tool-specific workflows
- Update 5 Cimas templates to call `generic-rake.yml` with appropriate inputs instead of `inkscape-rake`, `graphviz-rake`, `libreoffice-rake`, `xml2rfc-rake`
- Old workflow files are **kept unchanged** — they will be deleted in a follow-up PR after Cimas sync verifies all downstream repos pass CI

### Migration mapping

| Cimas template | Old workflow | New `setup-tools` |
|---|---|---|
| `inkscape/rake.yml` | `inkscape-rake.yml` | `inkscape,ghostscript` |
| `inkscape/rake-daily.yml` | `inkscape-rake.yml` | `inkscape,ghostscript` |
| `graphviz/rake.yml` | `graphviz-rake.yml` | `graphviz` |
| `libreoffice/rake.yml` | `libreoffice-rake.yml` | `libreoffice` |
| `xml2rfc/rake.yml` | `xml2rfc-rake.yml` | `xml2rfc` |

### Bug fix included

`libreoffice-rake.yml:36` uses `matrix.rubygems` instead of `matrix.ruby.rubygems` — migration to `generic-rake.yml` fixes this automatically.

## Test plan

- [x] `actionlint` passes on all modified files
- [ ] Cimas sync to downstream repos (post-merge)
- [ ] Verify CI passes on: `metanorma`, `isodoc`, `reverse_adoc`, `metanorma-ietf`
- [ ] Follow-up PR to delete old workflow files