### PR TITLE
feat: add reusable monorepo workflows

### DIFF
--- a/.github/workflows/monorepo-rake.yml
+++ b/.github/workflows/monorepo-rake.yml
@@ -1,0 +1,173 @@
+# Reusable workflow for monorepo gems that share a single Gemfile.
+#
+# Unlike the pubid-style monorepo (each gem has its own Gemfile), this
+# workflow assumes one top-level Gemfile with all gems loaded via `path:`
+# references. Spec directories are run sequentially within a single
+# `bundle install` per matrix cell.
+#
+# Usage (in the consuming repo):
+#   jobs:
+#     rake:
+#       uses: metanorma/ci/.github/workflows/monorepo-rake.yml@main
+#       with:
+#         spec-dirs: '["spec","coradoc-adoc/spec","coradoc-html/spec"]'
+#       secrets:
+#         pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+
+name: monorepo-rake
+
+on:
+  workflow_call:
+    inputs:
+      spec-dirs:
+        description: >-
+          JSON array of spec directories to run, e.g.
+          ["spec","coradoc-adoc/spec","coradoc-html/spec"]
+        required: false
+        type: string
+        default: '["spec"]'
+      tests-passed-event:
+        description: >-
+          Name of event sent with repository-dispatch after rake tests
+          are passed successfully
+        default: tests-passed
+        type: string
+      release-event:
+        description: Name of event sent to initiate release
+        default: do-release
+        type: string
+      before-setup-ruby:
+        description: Command to execute before setting up Ruby
+        type: string
+        default: ''
+        required: false
+      after-setup-ruby:
+        description: Command to execute after setting up Ruby
+        type: string
+        default: ''
+        required: false
+      setup-tools:
+        description: >-
+          Comma-separated list of tools to set up:
+          inkscape, ghostscript, graphviz, libreoffice, xml2rfc
+        type: string
+        default: ''
+        required: false
+      submodules:
+        description: 'Checkout submodules: true, false, or recursive'
+        type: string
+        default: 'recursive'
+        required: false
+      shell:
+        description: Shell to use for running commands
+        type: string
+        default: bash
+        required: false
+    secrets:
+      pat_token:
+        required: false
+
+jobs:
+  prepare:
+    uses: metanorma/ci/.github/workflows/prepare-rake.yml@main
+
+  rake:
+    name: Test on Ruby ${{ matrix.ruby.version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    needs: prepare
+    if: needs.prepare.outputs.push-for-tag != 'true'
+
+    concurrency:
+      group: >-
+        ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.ruby.version }}-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
+
+    continue-on-error: ${{ matrix.ruby.experimental }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+
+    defaults:
+      run:
+        shell: ${{ inputs.shell }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.pat_token || github.token }}
+          submodules: ${{ inputs.submodules }}
+
+      - if: matrix.os == 'windows-latest'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - if: ${{ inputs.before-setup-ruby != '' }}
+        run: ${{ inputs.before-setup-ruby }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby.version }}
+          bundler-cache: true
+          rubygems: ${{ matrix.ruby.rubygems }}
+          bundler: ${{ matrix.ruby.bundler }}
+
+      - if: ${{ inputs.after-setup-ruby != '' }}
+        run: ${{ inputs.after-setup-ruby }}
+
+      - if: contains(inputs.setup-tools, 'inkscape')
+        uses: metanorma/ci/inkscape-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'ghostscript')
+        uses: metanorma/ci/ghostscript-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'graphviz')
+        uses: metanorma/ci/graphviz-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'libreoffice')
+        uses: metanorma/ci/libreoffice-setup-action@main
+
+      - if: contains(inputs.setup-tools, 'xml2rfc')
+        uses: metanorma/ci/xml2rfc-setup-action@main
+
+      - name: Run specs for each gem
+        shell: bash
+        run: |
+          ruby -rjson -e '
+            dirs = JSON.parse(ENV["SPEC_DIRS"])
+            dirs.each do |dir|
+              label = dir == "spec" ? "core gem" : dir.sub(%r{/spec$}, "")
+              puts "::group::Running specs: #{label} (#{dir})"
+              ok = system("bundle", "exec", "rspec", dir, "--format", "progress")
+              puts "::endgroup::"
+              exit(1) unless ok
+            end
+          '
+        env:
+          SPEC_DIRS: ${{ inputs.spec-dirs }}
+
+  tests-passed:
+    needs: rake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        name: Tests passed
+        with:
+          token: ${{ secrets.pat_token || github.token }}
+          repository: ${{ github.repository }}
+          event-type: ${{ inputs.tests-passed-event }}
+          client-payload: >-
+            {"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.tests-passed-event }}"}
+
+      - if: startsWith(github.ref, 'refs/tags/v')
+        name: Repository ready for release
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.pat_token || github.token }}
+          repository: ${{ github.repository }}
+          event-type: ${{ inputs.release-event }}
+          client-payload: >-
+            {"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.release-event }}"}

--- a/.github/workflows/monorepo-rake.yml
+++ b/.github/workflows/monorepo-rake.yml
@@ -94,7 +94,7 @@ jobs:
         shell: ${{ inputs.shell }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.pat_token || github.token }}
           submodules: ${{ inputs.submodules }}

--- a/.github/workflows/monorepo-rubygems-release.yml
+++ b/.github/workflows/monorepo-rubygems-release.yml
@@ -77,7 +77,7 @@ jobs:
           ${{ inputs.gem_directory }}/${{ inputs.gem_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: ${{ inputs.submodules }}
           fetch-depth: 0
@@ -93,7 +93,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler-cache: true
           working-directory: >-
             ${{ inputs.gem_directory }}/${{ inputs.gem_name }}

--- a/.github/workflows/monorepo-rubygems-release.yml
+++ b/.github/workflows/monorepo-rubygems-release.yml
@@ -1,0 +1,164 @@
+# Reusable workflow for releasing an individual gem from a monorepo.
+#
+# Mirrors the single-gem rubygems-release.yml but adds monorepo support
+# via gem_name/gem_directory inputs that set the working directory.
+#
+# Usage (consumer repo creates a monorepo-release.yml that calls this):
+#   jobs:
+#     release:
+#       uses: metanorma/ci/.github/workflows/monorepo-rubygems-release.yml@main
+#       with:
+#         gem_name: coradoc-adoc
+#         gem_directory: .
+#         next_version: patch
+#       secrets:
+#         rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
+#         pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+
+name: monorepo-rubygems-release
+
+on:
+  workflow_call:
+    inputs:
+      gem_name:
+        description: >-
+          Directory name of the gem to release (relative to gem_directory).
+          Use "." for the root gem.
+        required: true
+        type: string
+      gem_directory:
+        description: Parent directory containing the gem directories
+        required: false
+        type: string
+        default: '.'
+      next_version:
+        description: >-
+          Next release version. Possible values: x.y.z, major, minor,
+          patch (or pre|rc|etc).  Pass 'skip' to skip 'git tag' and do
+          'gem push' for the current version.
+        required: true
+        type: string
+      release_command:
+        description: Override command to release the gem
+        required: false
+        type: string
+        default: ''
+      submodules:
+        description: Checkout submodules
+        required: false
+        type: boolean
+        default: true
+      environment:
+        description: >-
+          GitHub environment name for protection rules
+          (e.g. "release" for required approvers)
+        required: false
+        type: string
+        default: ''
+    secrets:
+      rubygems-api-key:
+        required: false
+      pat_token:
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      HAVE_PAT_TOKEN: ${{ secrets.pat_token != '' }}
+      HAS_API_KEY: ${{ secrets.rubygems-api-key != '' }}
+    defaults:
+      run:
+        working-directory: >-
+          ${{ inputs.gem_directory }}/${{ inputs.gem_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: ${{ inputs.submodules }}
+          fetch-depth: 0
+
+      - if: github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+        run: git fetch --tags origin
+        working-directory: .
+
+      - if: ${{ env.HAVE_PAT_TOKEN == 'true' }}
+        uses: metanorma/ci/gh-rubygems-setup-action@main
+        with:
+          token: ${{ secrets.pat_token }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: >-
+            ${{ inputs.gem_directory }}/${{ inputs.gem_name }}
+
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+        working-directory: .
+
+      - run: gem install gem-release
+        working-directory: .
+
+      # Version bump
+      - if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.next_version != 'skip'
+        run: gem bump --version ${{ inputs.next_version }} --tag --push
+
+      # Publish (API key path)
+      - if: ${{ env.HAS_API_KEY == 'true' }}
+        name: Publish to RubyGems (API key)
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.rubygems-api-key }}
+        run: |
+          mkdir -p ~/.gem
+          cat > ~/.gem/credentials << 'EOF'
+          ---
+          :rubygems_api_key: ${RUBYGEMS_API_KEY}
+          EOF
+          chmod 0600 ~/.gem/credentials
+          if [ -n "${{ inputs.release_command }}" ]; then
+            ${{ inputs.release_command }}
+          else
+            gem build *.gemspec
+            gem push *.gem
+          fi
+
+      # Publish (OIDC path)
+      - if: ${{ env.HAS_API_KEY != 'true' }}
+        name: Configure RubyGems credentials for Trusted Publishing
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
+
+      - if: ${{ env.HAS_API_KEY != 'true' && github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip' }}
+        run: gem bump --version ${{ inputs.next_version }} --tag --push
+
+      - if: ${{ env.HAS_API_KEY != 'true' }}
+        name: Build and push gem (OIDC)
+        run: |
+          gem build *.gemspec
+          gem push *.gem
+
+      # Post-release event
+      - name: Get current gem ref
+        id: gem-tag-ref
+        run: |
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).version.to_s")
+          echo "value=refs/tags/v${GEM_VERSION}" >> $GITHUB_OUTPUT
+
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.pat_token || github.token }}
+          repository: ${{ github.repository }}
+          event-type: release-passed
+          client-payload: >-
+            {"ref": "${{ steps.gem-tag-ref.outputs.value }}",
+             "sha": "${{ github.sha }}",
+             "type": "release-passed",
+             "gem-name": "${{ inputs.gem_name }}"}


### PR DESCRIPTION
## Summary

Add two new reusable workflows for monorepo-style gem projects that share a single top-level Gemfile (e.g., coradoc):

- **`monorepo-rake.yml`** — Tests multiple gems using a `spec-dirs` JSON input. Uses `prepare-rake.yml` for the standard Ruby (3.2, 3.4, 4.0) × OS (ubuntu, macos, windows) matrix. Runs specs for each directory sequentially with GHA group markers for visibility.

- **`monorepo-rubygems-release.yml`** — Per-gem release workflow that mirrors `rubygems-release.yml` with added `gem_name`/`gem_directory` inputs for working-directory support. Supports both API key and OIDC authentication.

### Pattern

Unlike the pubid-style monorepo (each gem in `gems/` with its own Gemfile), these workflows assume a single shared `Gemfile` with all gems loaded via `path:` references. This means one `bundle install` per matrix cell, then specs run for each gem directory.

### Usage (consumer repo)

```yaml
# .github/workflows/rake.yml
jobs:
  rake:
    uses: metanorma/ci/.github/workflows/monorepo-rake.yml@main
    with:
      spec-dirs: '["spec","coradoc-adoc/spec","coradoc-html/spec","coradoc-markdown/spec"]'
    secrets:
      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
```

## Test plan

- [ ] Consumer repo (coradoc) PR using this workflow passes all gem specs
- [ ] Ruby/OS matrix covers 3.2, 3.4, 4.0 × ubuntu, macos, windows