### PR TITLE
fix(release): honor dispatched ref so do-release works off non-default branches

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -61,6 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # On `repository_dispatch` events (e.g. `do-release` fired by `tests-passed`
+          # for a `v*` tag), GitHub forces the workflow to run on the default branch.
+          # Honor the dispatched ref so we release the tagged commit, not whatever
+          # `main` happens to point at — required for releases off non-default branches.
+          ref: ${{ github.event.client_payload.ref || github.ref }}
           submodules: ${{ inputs.submodules }}
 
       - if: github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'


### PR DESCRIPTION
## Summary

- Adds `ref: ${{ github.event.client_payload.ref || github.ref }}` to the `actions/checkout@v6` step in `.github/workflows/rubygems-release.yml`.
- Lets `do-release` (`repository_dispatch`) check out the tagged commit instead of the default branch's HEAD.
- `workflow_dispatch` / `workflow_call` paths unchanged (the expression falls through to `github.ref`).

## Why

GitHub forces `repository_dispatch` events to run on the default branch. The reusable release workflow had no `ref:` override on `actions/checkout`, so a `do-release` fired by a tag pushed off a non-default branch (e.g. a `v2.x` tag on `relaton-gb`'s `lutaml-integration` branch) ended up checking out `main`'s HEAD and trying to publish whatever version `main` was at — which is already on RubyGems, so `gem push` failed with `Repushing of gem versions is not allowed`.

Concrete failure: relaton/relaton-gb run [24162264552](https://github.com/relaton/relaton-gb/actions/runs/24162264552) — `do-release` fired by `v2.0.0` tagged on `lutaml-integration`, checked out `origin/main` (`d93da350…`, version 1.20.3), tried to repush 1.20.3.

The `tests-passed` job in `generic-rake.yml` already sends the right ref in its payload (`client-payload: '{"ref": "${{ github.ref }}", …}'`, gated on `if: startsWith(github.ref, 'refs/tags/v')`); this PR just makes the release workflow honor it.

This affects 30+ consumer gems in the `relaton/*` org and any other consumer of `metanorma/ci/.github/workflows/rubygems-release.yml`.

## Compatibility

- `repository_dispatch` (do-release): now checks out the dispatched tag ref. For tags pushed on `main`, the checked-out tree equals what `main`'s HEAD pointed at when the tag fired, so behavior matches the old path in the common case and is more correct in the rare case where `main` has moved on.
- `workflow_dispatch` and `workflow_call`: `client_payload.ref` is empty, so the expression falls through to `github.ref` — no change.

## Test plan

- [ ] Manual end-to-end on relaton-gb's `lutaml-integration`: hand-bump version, push tag, observe `do-release` checks out `refs/tags/vX.Y.Z` and `Pushed relaton-gb X.Y.Z to rubygems.org`.
- [ ] Regression: next routine main-branch release of any consumer gem behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)