### PR TITLE
ci: fix inkscape PPA add and docker gem-install test fixture

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -84,12 +84,15 @@ jobs:
           token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 
       - run: |
-          echo 'gem "metanorma-cli"' > Gemfile
-          echo 'gem "metanorma", "~>1"' >> Gemfile
+          # metanorma-cli is already locked in the metanorma/metanorma container
+          # image's Gemfile; re-declaring it here breaks bundler with
+          # "Gem already added".
+          echo 'gem "metanorma", "~>1"' > Gemfile
           echo 'gem "metanorma-nist", source: "https://rubygems.pkg.github.com/metanorma"' >> Gemfile
           echo 'gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"' >> Gemfile
 
-      - run: apt-get update -y && apt-get install -y gcc g++ ruby-dev
+      # libffi-dev + pkg-config are needed for fiddle's native extension build.
+      - run: apt-get update -y && apt-get install -y gcc g++ ruby-dev libffi-dev pkg-config
 
       - uses: ./docker-gem-install
 

--- a/inkscape-setup-action/action.yml
+++ b/inkscape-setup-action/action.yml
@@ -59,10 +59,24 @@ runs:
             "echo {}>> {}".format(win_prefix, os.environ["GITHUB_PATH"]),
             "\"{}\\inkscape\" --version".format(win_prefix)
           ],
+          # add-apt-repository goes through python-launchpadlib → api.launchpad.net,
+          # which intermittently times out from GitHub-hosted Ubuntu runners. The PPA's
+          # deb endpoint (ppa.launchpadcontent.net) and Ubuntu's keyserver are reliably
+          # reachable, so add the apt source and signing key directly. Key fingerprint
+          # comes from https://api.launchpad.net/1.0/~inkscape.dev/+archive/ubuntu/stable.
           "Ubuntu": [
-            "sudo add-apt-repository ppa:inkscape.dev/stable",
+            "sudo install -d -m 0755 /etc/apt/keyrings",
+            "sudo gpg --no-default-keyring "
+              "--keyring /etc/apt/keyrings/inkscape-dev-stable.gpg "
+              "--keyserver hkps://keyserver.ubuntu.com "
+              "--recv-keys 56BDFFD2F1C96B3D1575E3B85C9A0B86CD2FCB38",
+            ". /etc/os-release && echo "
+              "\"deb [signed-by=/etc/apt/keyrings/inkscape-dev-stable.gpg] "
+              "https://ppa.launchpadcontent.net/inkscape.dev/stable/ubuntu "
+              "$UBUNTU_CODENAME main\" "
+              "| sudo tee /etc/apt/sources.list.d/inkscape-dev-stable.list",
             "sudo apt update",
-            "sudo apt install inkscape={}".format(version),
+            "sudo apt install -y inkscape={}".format(version),
             "which inkscape",
             "inkscape --version"
           ],

--- a/inkscape-setup-action/action.yml
+++ b/inkscape-setup-action/action.yml
@@ -61,15 +61,18 @@ runs:
           ],
           # add-apt-repository goes through python-launchpadlib → api.launchpad.net,
           # which intermittently times out from GitHub-hosted Ubuntu runners. The PPA's
-          # deb endpoint (ppa.launchpadcontent.net) and Ubuntu's keyserver are reliably
-          # reachable, so add the apt source and signing key directly. Key fingerprint
-          # comes from https://api.launchpad.net/1.0/~inkscape.dev/+archive/ubuntu/stable.
+          # deb endpoint (ppa.launchpadcontent.net) and keyserver.ubuntu.com's HTTPS
+          # lookup are reliably reachable, so add the apt source and signing key directly.
+          # `gpg --dearmor` is used (not --recv-keys) because the runner image has no
+          # dirmngr / no /root/.gnupg, which breaks the OpenPGP keyserver path.
+          # Key fingerprint comes from
+          # https://api.launchpad.net/1.0/~inkscape.dev/+archive/ubuntu/stable.
           "Ubuntu": [
             "sudo install -d -m 0755 /etc/apt/keyrings",
-            "sudo gpg --no-default-keyring "
-              "--keyring /etc/apt/keyrings/inkscape-dev-stable.gpg "
-              "--keyserver hkps://keyserver.ubuntu.com "
-              "--recv-keys 56BDFFD2F1C96B3D1575E3B85C9A0B86CD2FCB38",
+            "curl -fsSL "
+              "'https://keyserver.ubuntu.com/pks/lookup"
+              "?op=get&search=0x56BDFFD2F1C96B3D1575E3B85C9A0B86CD2FCB38' "
+              "| sudo gpg --dearmor -o /etc/apt/keyrings/inkscape-dev-stable.gpg",
             ". /etc/os-release && echo "
               "\"deb [signed-by=/etc/apt/keyrings/inkscape-dev-stable.gpg] "
               "https://ppa.launchpadcontent.net/inkscape.dev/stable/ubuntu "


### PR DESCRIPTION
## Summary

Two unrelated regressions in the `test-composite` workflow, both blocking every PR (including #263). Fixed in one PR since both touch the same workflow.

### 1. `inkscape-setup-action` — bypass `add-apt-repository`

`sudo add-apt-repository ppa:inkscape.dev/stable` invokes Python's `softwareproperties` → `launchpadlib` → `api.launchpad.net`, which has been timing out from GitHub-hosted Ubuntu runners:

```
File ".../httplib2/__init__.py", line 1133, in connect
    sock.connect((self.host, self.port))
TimeoutError: [Errno 110] Connection timed out
```

Launchpad itself is up — `ppa.launchpadcontent.net` and `keyserver.ubuntu.com` are both reachable from runners; only the REST API path is broken. Replace `add-apt-repository` with a direct apt source + key fetch.

Signing key fingerprint `56BDFFD2F1C96B3D1575E3B85C9A0B86CD2FCB38` taken from `https://api.launchpad.net/1.0/~inkscape.dev/+archive/ubuntu/stable` (`signing_key_fingerprint`).

### 2. `ci-test.yml` `test-gem-docker` fixture — two cascading bugs

```
[!] You cannot specify the same gem twice with different version requirements.
You specified: metanorma-cli (= 1.15.7) and metanorma-cli (>= 0). Gem already added.
```

The fixture's Gemfile redeclared `metanorma-cli`, which is already locked in the `metanorma/metanorma` container image. Removed.

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
checking for pkg-config for libffi... not found
```

A transitive dep (`fiddle 1.1.8`) needs libffi to build. Added `libffi-dev` + `pkg-config` to the apt-get line.

## Concrete failure refs

- Run [25241295243](https://github.com/metanorma/ci/actions/runs/25241295243) — both failures are reproducing across multiple re-run attempts (currently attempt #5).
- The last successful `test-composite` run on `main` was 2026-04-27; nothing has run on `main` since, so these regressions haven't shown up there yet but will on the next `main` build.

## Compatibility

- macOS / Windows / generic-Linux branches of `inkscape-setup-action` untouched.
- The `test-gem-docker-gh-rubygem-setup-action` matrix variant (the one in `metanorma/metanorma:ubuntu-latest`, not the plain `metanorma/metanorma`) was already passing and isn't touched.

## Test plan

- [ ] `Test composite actions ubuntu-latest` goes green; expect to see `gpg: key 5C9A0B86CD2FCB38: public key "Launchpad PPA for Inkscape Developers" imported`, `Get:1 https://ppa.launchpadcontent.net/inkscape.dev/stable/ubuntu noble InRelease`, and `Inkscape 1.4.x` from `inkscape --version`.
- [ ] `Test gh-rubygems-setup-action & docker-gem-install in docker` (plain `metanorma/metanorma` variant) goes green; Bundler resolves without "Gem already added" and `fiddle` builds.
- [ ] `Test composite actions macos-latest` and `windows-latest` remain green (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)