### PR TITLE
fix: pass pat_token to checkout for private submodule access

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -67,6 +67,7 @@ jobs:
           # `main` happens to point at — required for releases off non-default branches.
           ref: ${{ github.event.client_payload.ref || github.ref }}
           submodules: ${{ inputs.submodules }}
+          token: ${{ secrets.pat_token || github.token }}
 
       - if: github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
         run: git fetch --tags origin


### PR DESCRIPTION
## Problem

The `rubygems-release.yml` reusable workflow checks out repos with `submodules: true`, but doesn't pass the `pat_token` to `actions/checkout`. This causes failures for repos with private submodules (e.g., uniword → uniword-private) because the default `github.token` can't access private repos in other repositories.

## Fix

Pass `token: ${{ secrets.pat_token || github.token }}` to the checkout step. Falls back to the default token when no PAT is provided.

## Testing

- Repos without submodules: unchanged behavior (falls back to `github.token`)
- Repos with public submodules: unchanged behavior
- Repos with private submodules: PAT token now authenticates the submodule clone