### PR TITLE
fix: monorepo release workflow credentials and syntax errors

### DIFF
--- a/.github/workflows/monorepo-rubygems-release.yml
+++ b/.github/workflows/monorepo-rubygems-release.yml
@@ -8,12 +8,16 @@
 #     release:
 #       uses: metanorma/ci/.github/workflows/monorepo-rubygems-release.yml@main
 #       with:
-#         gem_name: coradoc-adoc
+#         gem_name: coradoc-adoc    # sub-gem directory name, or "." for root gem
 #         gem_directory: .
 #         next_version: patch
 #       secrets:
 #         rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
 #         pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+#
+# To override the build/publish command:
+#   with:
+#     release_command: bundle exec rake release
 
 name: monorepo-rubygems-release
 
@@ -39,10 +43,12 @@ on:
         required: true
         type: string
       release_command:
-        description: Override command to release the gem
+        description: >-
+          Command to build and publish the gem. Defaults to
+          `gem build *.gemspec && gem push *.gem`.
         required: false
         type: string
-        default: ''
+        default: 'gem build *.gemspec && gem push *.gem'
       submodules:
         description: Checkout submodules
         required: false
@@ -119,17 +125,12 @@ jobs:
           RUBYGEMS_API_KEY: ${{ secrets.rubygems-api-key }}
         run: |
           mkdir -p ~/.gem
-          cat > ~/.gem/credentials << 'EOF'
+          envsubst << 'EOF' > ~/.gem/credentials
           ---
           :rubygems_api_key: ${RUBYGEMS_API_KEY}
           EOF
           chmod 0600 ~/.gem/credentials
-          if [ -n "${{ inputs.release_command }}" ]; then
-            ${{ inputs.release_command }}
-          else
-            gem build *.gemspec
-            gem push *.gem
-          fi
+          ${{ inputs.release_command }}
 
       # Publish (OIDC path)
       - if: ${{ env.HAS_API_KEY != 'true' }}


### PR DESCRIPTION
## Problem

The `monorepo-rubygems-release.yml` workflow has two bugs that prevent gem publication:

### Bug 1: Credentials not expanded

```bash
cat > ~/.gem/credentials << 'EOF'
---
:rubygems_api_key: ${RUBYGEMS_API_KEY}
EOF
```

The single-quoted heredoc (`'EOF'`) prevents bash from expanding `${RUBYGEMS_API_KEY}`, so the credentials file contains the literal string `${RUBYGEMS_API_KEY}` instead of the actual API key. The non-monorepo `rubygems-release.yml` correctly uses `envsubst` to handle this.

### Bug 2: Bash syntax error

```bash
if [ -n "" ]; then
  <empty>            # ${{ inputs.release_command }} resolves to empty
else
  gem build *.gemspec
  gem push *.gem
fi
```

When `release_command` is empty (default `''`), the `then` body is effectively empty, causing:

```
/home/runner/work/_temp/xxx.sh: line 9: syntax error near unexpected token `else