### PR TITLE
fix: tool-setup-action relative paths break reusable workflow consumers

### DIFF
--- a/tool-setup-action/action.yml
+++ b/tool-setup-action/action.yml
@@ -20,25 +20,25 @@ runs:
     - if: >-
         inputs.setup-inkscape == 'true' ||
         contains(format(',{0},', inputs.setup-tools), ',inkscape,')
-      uses: ./inkscape-setup-action
+      uses: metanorma/ci/inkscape-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',ghostscript,')
-      uses: ./ghostscript-setup-action
+      uses: metanorma/ci/ghostscript-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',graphviz,')
-      uses: ./graphviz-setup-action
+      uses: metanorma/ci/graphviz-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',libreoffice,')
-      uses: ./libreoffice-setup-action
+      uses: metanorma/ci/libreoffice-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',xml2rfc,')
-      uses: ./xml2rfc-setup-action
+      uses: metanorma/ci/xml2rfc-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',exiftool,')
-      uses: ./exiftool-setup-action
+      uses: metanorma/ci/exiftool-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',ffmpeg,')
-      uses: ./ffmpeg-setup-action
+      uses: metanorma/ci/ffmpeg-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',imagemagick,')
-      uses: ./imagemagick-setup-action
+      uses: metanorma/ci/imagemagick-setup-action@main


### PR DESCRIPTION
Fixes a critical regression from PR #268.

`tool-setup-action` used `./<tool>-setup-action` relative paths in its composite action steps. When called from a reusable workflow in a consumer repo (e.g. `lutaml/lutaml`), GitHub resolves `./` against the consumer's workspace — not the metanorma/ci repo — causing all tool setup steps to fail with `Can't find action.yml`.

**Fix:** Use full remote references (`metanorma/ci/<tool>-setup-action@main`) instead of relative paths.

**Impact:** All repos using `generic-rake.yml`, `dependent-rake.yml`, or `monorepo-rake.yml` with `setup-tools` are currently broken on main.