### PR TITLE
Drop Ruby 3.2 from CI matrix, add 3.3

### DIFF
--- a/.github/workflows/ruby-matrix.json
+++ b/.github/workflows/ruby-matrix.json
@@ -1,7 +1,7 @@
 {
   "ruby": [
     {
-      "version": "3.2",
+      "version": "3.3",
       "rubygems": "latest",
       "bundler": "default",
       "experimental": false

--- a/.github/workflows/sample-test.yml
+++ b/.github/workflows/sample-test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        ruby: [ '3.2', '3.3', '3.4' ]
+        ruby: [ '3.3', '3.4' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         experimental: [ false ]
         include:

--- a/.github/workflows/template-test.yml
+++ b/.github/workflows/template-test.yml
@@ -29,7 +29,7 @@ jobs:
 
           cat .github/workflows/matrix.json                                        | \
             jq '. + {"experimental": [false]}'                                     | \
-            jq '. + {"ruby": ["3.4", "3.3", "3.2", "4.0"]}'                        | \
+            jq '. + {"ruby": ["3.4", "3.3", "4.0"]}'                               | \
             jq -c '. + {"os": ["macos-latest", "ubuntu-latest", "windows-latest" ]}' \
             > matrix.json.tmp && mv matrix.json.tmp .github/workflows/matrix.json
 


### PR DESCRIPTION
## Summary

Drop Ruby 3.2 from the central CI matrix and add 3.3 in its place. The supported test matrix becomes **3.3 / 3.4 / 4.0-experimental**.

Refs metanorma/ci#274 (Ruby 3.2 reached EOL on 2026-03-31).

## Why this is a one-PR change, not a stack-wide sync

Every downstream metanorma rake workflow (e.g. `html2doc/.github/workflows/rake.yml`) is a thin caller of `metanorma/ci/.github/workflows/generic-rake.yml@main`. Inside that reusable workflow, [`prepare-rake.yml`](.github/workflows/prepare-rake.yml) does:

```bash
curl -L https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/ruby-matrix.json
```

at runtime, and feeds the result into `strategy.matrix`. So editing **this one JSON file on `main`** immediately becomes the matrix for every downstream rake run on the next push/PR — no cimas sync, no per-repo PRs, no gemspec rewrites required to move the CI floor.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/ruby-matrix.json` | Replace the `3.2` entry with a `3.3` entry. Canonical matrix curled at runtime by `prepare-rake.yml`. |
| `.github/workflows/template-test.yml` | Drop `"3.2"` from the hard-coded `jq '. + {"ruby": [...]}'` list. 3.3 was already present. |
| `.github/workflows/sample-test.yml` | Drop `'3.2'` from the hard-coded `ruby: [...]` matrix. 3.3 was already present; 4.0 comes in via the `include:` block below and is unchanged. |

Total: 3 single-line changes.

## Out of scope (deliberately)

- **Gemspec `required_ruby_version` lines** across the ~50 metanorma gems still declare `>= 3.1` or similar. That is documentation lag, not a CI failure, and is the natural first real use of [cimas#38](https://github.com/metanorma/cimas/pull/38) (`patches:` sync mode) once that PR has been tested independently. Tracked on the linked issue.
- **`config.json`** already pins `default_ruby_version` to `3.3.5`, so no change is needed there.

## Verification

- `jq . .github/workflows/ruby-matrix.json` parses cleanly after the edit.
- Both updated YAMLs parse cleanly under Ruby's `YAML.load_file`.
- `grep -rn "[^0-9.]3\.2[^0-9]" .github cimas-config` returns no matches after the edits.

After merge, the verification path is: trigger a rake run on a small downstream repo (e.g. `html2doc`) — either an empty commit or a re-run from the Actions UI — and confirm the resulting matrix shows three Ruby rows (3.3, 3.4, 4.0) across the three OSes and no 3.2 row.
