### PR TITLE
tests-passed: restore PAT on repository_dispatch steps to keep downstream chain alive: https://github.com/metanorma/ci/issues/276

### DIFF
--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -140,6 +140,7 @@ jobs:
       - uses: peter-evans/repository-dispatch@v3
         name: Tests passed
         with:
+          token: ${{ secrets.pat_token || github.token }}
           repository: ${{ github.repository }}
           event-type: ${{ inputs.tests-passed-event }}
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.tests-passed-event }}"}'
@@ -148,6 +149,7 @@ jobs:
         name: Repository ready for release
         uses: peter-evans/repository-dispatch@v3
         with:
+          token: ${{ secrets.pat_token || github.token }}
           repository: ${{ github.repository }}
           event-type: ${{ inputs.release-event }}
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.release-event }}"}'


### PR DESCRIPTION
## Summary

Recrafted per @ronaldtse's review on this PR ([first comment](https://github.com/metanorma/ci/pull/277#issuecomment-3548559310), [second comment](https://github.com/metanorma/ci/pull/277#issuecomment-3548562537), [confirmation](https://github.com/metanorma/ci/pull/277#issuecomment-4459367395)).

**Single change:** Add `token: ${{ secrets.pat_token || github.token }}` back on both `peter-evans/repository-dispatch@v3` steps in the `tests-passed` job of `.github/workflows/generic-rake.yml`. Net diff is +2 lines.

## What changed vs the previous version of this PR

The previous version of this PR did two things: (a) restored the PAT, and (b) removed the job-level `permissions: contents: write` on `tests-passed`. Per @ronaldtse, (b) was wrong — `tests-passed` is the consolidation step and **does** need to declare `contents: write`. So this recraft drops (b) and only keeps (a).

The job-level `permissions: contents: write` on `tests-passed` is therefore **retained as it is on `main`** (added in `30a34e4`). This PR no longer touches it.

## What this PR addresses

**Consequence 2 of #276** only: cross-workflow `repository_dispatch` chaining. `repository_dispatch` events fired with `GITHUB_TOKEN` do not trigger other workflows (GitHub anti-recursion rule); only PAT-fired dispatches chain into downstream workflows. Without the PAT restore, the `tests-passed → do-release` chain runs green but silently fails to fire anything downstream.

## What this PR does NOT address (and how it will be addressed)

**Consequence 1 of #276**: caller `rake.yml` files that declare `permissions: contents: read` (e.g. [metanorma-plugin-datastruct](https://github.com/metanorma/metanorma-plugin-datastruct/commit/066c51e), confirmed failing at [run 25729244694](https://github.com/metanorma/metanorma-plugin-datastruct/actions/runs/25729244694) with `startup_failure`) are rejected at validation because the caller's cap (`read`) is below what `tests-passed` requests (`write`).

Per @ronaldtse's direction (option B in [my clarifying comment](https://github.com/metanorma/ci/pull/277#issuecomment-4459310108)), this is to be fixed **in the calling workflow** — i.e. the caller's auto-generated `rake.yml` should declare `permissions: contents: write` at its workflow level, lifting the cap. That requires:

1. A separate PR updating the Cimas templates at [`cimas-config/gh-actions/master/`](https://github.com/metanorma/ci/tree/main/cimas-config/gh-actions/master) so generated caller `rake.yml` files declare `permissions: contents: write` at workflow level.
2. Regeneration of caller `rake.yml` files across the affected metanorma repos via Cimas.

Until (1) and (2) land, callers that currently cap at `contents: read` will continue to hit the validation failure on tag pushes that route through `tests-passed`. They can be unblocked individually by removing or upgrading the cap manually.

## My interpretation, explicit

I'm reading @ronaldtse's "move the permissions block to the workflow level" + "I meant (B)" as: **the caller** declares `permissions: contents: write` at its workflow level (to lift the cap); **the called workflow** keeps its job-level `permissions: contents: write` on `tests-passed` exactly as it is on `main` (so the declaration of what TP needs stays where it is). The "move" is about adding the grant in the caller, not removing the declaration here.

If that's not what you meant, please correct — I'd rather get it wrong now than silently get it wrong in the Cimas template PR.

## Sibling workflows

Same `tests-passed`/`do-release` pattern lives in `xml2rfc-rake.yml`, `inkscape-rake.yml`, `monorepo-rake.yml`, `mn-processor-rake.yml`, `libreoffice-rake.yml`, `graphviz-rake.yml`, `rubygems-release.yml`. The PAT restore needs parallel application there. Happy to chain follow-ups once this lands.

## Test plan

- [ ] After merge of this PR + the Cimas template PR + caller regeneration: push to a regenerated caller (e.g. `metanorma-plugin-datastruct`) on a tag that routes through `tests-passed`. Confirm validation passes (no `startup_failure`) AND the downstream `repository_dispatch` listener actually fires.
- [ ] Until the Cimas PR lands, the validation failure in capped callers is expected and unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
