### PR TITLE
inkscape-setup-action: retry network installs to absorb transient download flakes: https://github.com/metanorma/ci/issues/279

### DIFF
--- a/_shared/tool_runner.py
+++ b/_shared/tool_runner.py
@@ -6,6 +6,7 @@ composite actions in this repository.
 
 import os
 import sys
+import time
 import platform
 import subprocess
 
@@ -58,3 +59,29 @@ def run_commands(cmds):
         if result.returncode != 0:
             print(f"Command FAILED: {cmd}")
             sys.exit(1)
+
+
+def run_commands_with_retry(cmds, retries=3, delay=15):
+    """Run `cmds` as a sequence; retry the whole sequence on any failure.
+
+    Useful for network-bound install steps that hit transient HTTP/2,
+    DNS, or mirror flakes. Up to `retries` total attempts, with `delay`
+    seconds between attempts. Exits 1 if all attempts fail.
+    """
+    for attempt in range(1, retries + 1):
+        ok = True
+        for cmd in cmds:
+            print(f"> {cmd}")
+            sys.stdout.flush()
+            result = subprocess.run(cmd, shell=True)
+            if result.returncode != 0:
+                print(f"Command FAILED (attempt {attempt}/{retries}): {cmd}")
+                ok = False
+                break
+        if ok:
+            return
+        if attempt < retries:
+            print(f"Retrying in {delay}s...")
+            sys.stdout.flush()
+            time.sleep(delay)
+    sys.exit(1)

--- a/inkscape-setup-action/action.yml
+++ b/inkscape-setup-action/action.yml
@@ -11,7 +11,11 @@ runs:
       run: |
         import sys, os
         sys.path.insert(0, os.path.join(os.environ['GITHUB_ACTION_PATH'], '..', '_shared'))
-        from tool_runner import get_platform_name, run_commands
+        from tool_runner import (
+            get_platform_name,
+            run_commands,
+            run_commands_with_retry,
+        )
 
         platform_name = get_platform_name()
 
@@ -25,14 +29,18 @@ runs:
         }.get(platform_name, None)
 
         if platform_name == "Windows":
-          run_commands([
+          run_commands_with_retry([
             "choco install --no-progress -y inkscape --verbose",
+          ])
+          run_commands([
             "echo {}>> {}".format(win_prefix, os.environ["GITHUB_PATH"]),
             "\"{}\\inkscape\" --version".format(win_prefix),
           ])
         elif platform_name == "Ubuntu":
           run_commands([
             "sudo install -d -m 0755 /etc/apt/keyrings",
+          ])
+          run_commands_with_retry([
             "curl -fsSL "
               "'https://keyserver.ubuntu.com/pks/lookup"
               "?op=get&search=0x56BDFFD2F1C96B3D1575E3B85C9A0B86CD2FCB38' "
@@ -44,18 +52,26 @@ runs:
               "| sudo tee /etc/apt/sources.list.d/inkscape-dev-stable.list",
             "sudo apt update",
             "sudo apt install -y inkscape={}".format(version),
+          ])
+          run_commands([
             "which inkscape",
             "inkscape --version",
           ])
         elif platform_name == "Linux":
-          run_commands([
+          run_commands_with_retry([
             "wget {} -O /usr/local/bin/inkscape".format(version),
+          ])
+          run_commands([
             "sudo chmod +x /usr/local/bin/inkscape",
             "inkscape --version",
           ])
         elif platform_name == "Darwin":
-          run_commands([
+          os.environ["HOMEBREW_CURL_RETRIES"] = "3"
+          os.environ["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+          run_commands_with_retry([
             "HOMEBREW_CASK_OPTS='--no-quarantine' brew install --cask inkscape",
+          ])
+          run_commands([
             "inkscape --version",
           ])
         else:


### PR DESCRIPTION
## Summary

Closes https://github.com/metanorma/ci/issues/279.

The `inkscape-setup-action` is exposed to transient HTTP/2 mid-stream errors
when downloading the inkscape cask/AppImage/MSI/deb. Today the action runs
each install command exactly once via `_shared/tool_runner.py:run_commands`
and exits 1 on any non-zero rc — there is no retry anywhere in the inkscape
path. This PR adds one.

## What changed

1. **`_shared/tool_runner.py`** — new `run_commands_with_retry(cmds,
   retries=3, delay=15)` helper. Runs the command sequence; on any failure,
   sleeps `delay` seconds and re-runs the whole sequence; gives up after
   `retries` total attempts.

2. **`inkscape-setup-action/action.yml`** — wraps the **network-bound
   install** commands in `run_commands_with_retry` on all four platforms:

   - Windows: `choco install … inkscape`
   - Ubuntu: keyring fetch + `apt update` + `apt install`
   - Linux: `wget … AppImage`
   - Darwin: `brew install --cask inkscape`

   Deterministic post-install steps (`inkscape --version`, PATH echo on
   Windows, `chmod +x` on Linux, `which inkscape` on Ubuntu) remain on
   plain `run_commands` — they shouldn't be retried.

3. **Darwin-specific env hardening**:
   - `HOMEBREW_CURL_RETRIES=3` — Homebrew's own per-curl-download retry,
     which would have caught the specific HTTP/2 mid-stream failure in
     issue #279 *inside* the single brew invocation.
   - `HOMEBREW_NO_AUTO_UPDATE=1` — skip the implicit pre-install `brew
     update`, which is itself an unrelated flake surface.

## Verification

- Helper import + YAML parse + inline-Python compile checked locally.
- Stub-tested the retry path: simulated two failures, third attempt
  succeeds, total of 3 subprocess calls — confirms the loop counts and
  exits cleanly on recovery.
- Live verification requires a workflow run. Triggering one of the
  workflows that uses `inkscape-setup-action` (e.g. `inkscape-rake.yml`)
  against this branch should produce green runs on all four runner OSes
  with no observable behaviour change in the happy path.

## Out of scope (tracked in issue #279)

- Pinning explicit inkscape versions per platform.
- Falling back to a cached/`cimas`-style mirror when upstream is down.
- Moving the retry behaviour into a `setup-tool` meta-action so every
  setup action picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
