### PR TITLE
Fix Cimas Makefile template lutaml CLI for gem 0.10.18: https://github.com/metanorma/ci/issues/281

### DIFF
--- a/cimas-config/gh-actions/model/Makefile
+++ b/cimas-config/gh-actions/model/Makefile
@@ -18,7 +18,7 @@ PNG := $(patsubst views/%.lutaml,images/%.png,$(SRC))
 all: $(PNG)
 
 images/%.png: views/%.lutaml
-	lutaml -t png -o $@ $<
+	lutaml lml generate $< -o $@
 
 views/%.lutaml: models/%.wsd | views
 	lutaml-wsd2uml $< > $@


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/281.

## Summary

Patches `cimas-config/gh-actions/model/Makefile` line 21 to use the post-0.10.18 `lutaml` CLI:

```diff
 images/%.png: views/%.lutaml
-	lutaml -t png -o $@ $<
+	lutaml lml generate $< -o $@
```

The `lutaml` gem 0.10.18 reorganised into Thor subcommands; diagram generation moved to `lutaml lml generate <input> -o <output>`, with the output format inferred from the extension (so `-t png` is no longer needed). `lutaml-wsd2uml` at line 24 is unchanged — that binary still ships as a standalone.

## Affected repos

Every `metanorma/metanorma-model-*` whose Makefile is Cimas-generated (verified by inspection of the `# Auto-generated by Cimas: Do not edit it manually!` header):

- `metanorma/metanorma-model-iso` — tactically patched in commit on its main branch
- `metanorma/metanorma-model-bsi` — tactically patched
- `metanorma/metanorma-model-csd` — tactically patched
- `metanorma/metanorma-model-itu` — tactically patched
- `metanorma/metanorma-model-nist` — tactically patched (on `master` — its default branch)
- `metanorma/metanorma-model-ogc` — tactically patched
- `metanorma/metanorma-model-standoc` — tactically patched

The tactical patches got CI green on each of those repos today. Without this template fix, the next Cimas regeneration would re-emit the broken Makefile line and reintroduce the failure. After this PR merges, regenerating any of the affected repos via Cimas re-emits the corrected line.

## Test plan

- [ ] Manual smoke test: run Cimas regeneration against one of the affected repos and confirm the generated Makefile carries the new CLI invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
