### PR TITLE
Pin Cimas automerge template to pascalgn/automerge-action@v0.16.4: https://github.com/metanorma/ci/issues/283

### DIFF
--- a/cimas-config/gh-actions/master/automerge.yml
+++ b/cimas-config/gh-actions/master/automerge.yml
@@ -24,6 +24,6 @@ jobs:
     steps:
       - id: automerge
         name: automerge
-        uses: pascalgn/automerge-action@v0.16
+        uses: pascalgn/automerge-action@v0.16.4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/283.

## Summary

Pins the Cimas automerge.yml template to a real published tag.

```diff
-        uses: pascalgn/automerge-action@v0.16
+        uses: pascalgn/automerge-action@v0.16.4
```

`@v0.16` was never published — the 0.16 line ships as `v0.16.0` through `v0.16.4`. GitHub Actions resolves tags exactly, so the workflow fails to find the action.

`@v0.16.4` is the latest patch in the 0.16 line (2024-09-22). Pinning to a specific patch avoids surprise upgrades on every CI run.

## Affected repos already patched direct

To unblock CI today, the same one-line pin bump went direct to:

- `metanorma/metanorma-model-iso@main`
- `metanorma/metanorma-model-standoc@main`

Both are Cimas-regenerated repos; without this template fix, the next regeneration would re-emit the broken `@v0.16` pin. After this PR lands, regeneration emits the corrected pin.

Older `metanorma-model-*` repos still pinned at `@v0.12.0` (the previous Cimas generation) are not affected and will pick up `@v0.16.4` on their next regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
