### PR TITLE
fix: clean gitignored files before gem bump

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -100,8 +100,8 @@ jobs:
 
       - run: gem install gem-release
 
-      - name: Clean gitignored files before bump
-        run: git clean -fdX
+      - name: Remove Gemfile.lock before bump
+        run: rm -f Gemfile.lock
 
       # ============ API Key Path ============
       - if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip' && env.HAS_API_KEY == 'true'

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -100,6 +100,9 @@ jobs:
 
       - run: gem install gem-release
 
+      - name: Clean gitignored files before bump
+        run: git clean -fdX
+
       # ============ API Key Path ============
       - if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip' && env.HAS_API_KEY == 'true'
         run: gem bump --version ${{ inputs.next_version }} --tag --push


### PR DESCRIPTION
## Problem

`gem bump` in `rubygems-release.yml` aborts with `"Uncommitted changes found. Please commit or stash. Aborting."` when the repo gitignores `Gemfile.lock` (or other files that CI steps create).

This affects repos like [lutaml/moxml](https://github.com/lutaml/moxml) where `Gemfile.lock` is gitignored — `bundle install` creates an untracked lock file, and `gem bump` refuses to proceed.

## Fix

Add `git clean -fdX` before `gem bump` to remove any gitignored files that CI steps may have generated. This only removes files matching `.gitignore` patterns, not arbitrary untracked files.

## Example failure

https://github.com/lutaml/moxml/actions/runs/26726642032/job/78762951263