### PR TITLE
fix: stash uncommitted changes before gem bump

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -100,8 +100,8 @@ jobs:
 
       - run: gem install gem-release
 
-      - name: Remove Gemfile.lock before bump
-        run: rm -f Gemfile.lock
+      - name: Stash uncommitted changes before bump
+        run: git stash --include-untracked || true
 
       # ============ API Key Path ============
       - if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip' && env.HAS_API_KEY == 'true'


### PR DESCRIPTION
## Problem

Follow-up to #285. The `rm -f Gemfile.lock` fix was insufficient — `bundle install` with `bundler-cache` also creates `vendor/bundle/` and `.bundle/config` as untracked files, causing `gem bump` to still abort.

## Fix

Use `git stash --include-untracked` instead of removing a specific file. This temporarily hides ALL uncommitted changes (tracked modifications, untracked files, and gitignored files) before `gem bump` runs.

This is safe because:
- `gem bump` commits and pushes its own version bump — it does not need the stashed content
- The stash is temporary and does not affect the pushed commit
- Does NOT delete any files (unlike `git clean`), so generated frontend assets and other build artifacts remain in the stash if needed later in the workflow

## Testing

Failed with just `rm -f Gemfile.lock`: https://github.com/lutaml/moxml/actions/runs/26732999948