### PR TITLE
fix: detect tag on tag push events to skip duplicate test runs

### DIFF
--- a/.github/workflows/prepare-rake.yml
+++ b/.github/workflows/prepare-rake.yml
@@ -43,7 +43,9 @@ jobs:
         run: |
           fpr="no"
           tag=""
-          if [[ "${{ github.ref }}" == refs/heads/* ]]; then
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            tag="${{ github.ref_name }}"
+          elif [[ "${{ github.ref }}" == refs/heads/* ]]; then
             tag="$(git tag --points-at HEAD)"
           elif [[ "${{ github.ref }}" == refs/pull/* ]] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
             fpr="yes"


### PR DESCRIPTION
## Problem

When a tag push triggers the rake workflow, prepare-rake.yml only checks for tags on `refs/heads/*` refs. Tag push events (`refs/tags/v*`) fall through with `head_tag=""`, so `push_for_tag` evaluates to false, and tests run unnecessarily.

This causes a double-publish race in rubygems-release.yml:

1. `workflow_dispatch` with `next_version=patch` bumps, tags, pushes, and publishes the gem
2. Tag push triggers rake workflow - tests run (should be skipped!) - tests-passed dispatches do-release
3. do-release checks out the same tag and tries to publish again - fails with "Repushing of gem versions is not allowed"

Example failure: https://github.com/lutaml/lutaml-model/actions/runs/27004489027

## Root cause

The tag detection in prepare-rake.yml only matches refs/heads/*:

```bash
if [[ "${{ github.ref }}" == refs/heads/* ]]; then
  tag="$(git tag --points-at HEAD)"
elif ...
```

For a tag push event, github.ref is refs/tags/v0.8.16, which does not match refs/heads/*, so tag stays empty.

## Fix

Check refs/tags/* first using github.ref_name, then fall back to git tag --points-at HEAD for branch pushes.

```bash
if [[ "${{ github.ref }}" == refs/tags/* ]]; then
  tag="${{ github.ref_name }}"
elif [[ "${{ github.ref }}" == refs/heads/* ]]; then
  tag="$(git tag --points-at HEAD)"
elif ...
```

With head_tag correctly set on tag pushes, push_for_tag = true, the rake job is skipped, and do-release is never dispatched redundantly.

## Behavior matrix

| Event | github.ref | Before | After |
|-------|-----------|--------|-------|
| Push to branch (no tag) | refs/heads/main | Tests run | Tests run |
| Push to branch (tagged HEAD) | refs/heads/main | Tests skip | Tests skip |
| Tag push | refs/tags/v1.0 | Tests run (bug) | Tests skip |
| PR | refs/pull/1/merge | Tests run | Tests run |
| workflow_dispatch | refs/heads/main | Tests run | Tests run |
| repository_dispatch | refs/heads/main | Tests run | Tests run |