### PR TITLE
Restore tag-push test matrix without re-introducing #287's double-publish

### DIFF
--- a/.github/workflows/prepare-rake.yml
+++ b/.github/workflows/prepare-rake.yml
@@ -43,9 +43,7 @@ jobs:
         run: |
           fpr="no"
           tag=""
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            tag="${{ github.ref_name }}"
-          elif [[ "${{ github.ref }}" == refs/heads/* ]]; then
+          if [[ "${{ github.ref }}" == refs/heads/* ]]; then
             tag="$(git tag --points-at HEAD)"
           elif [[ "${{ github.ref }}" == refs/pull/* ]] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
             fpr="yes"

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -112,6 +112,13 @@ jobs:
         env:
           RUBYGEMS_API_KEY: ${{ secrets.rubygems-api-key }}
         run: |
+          GEM_NAME=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).name")
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).version.to_s")
+          if gem list -r --exact -v "$GEM_VERSION" "$GEM_NAME" 2>/dev/null \
+               | grep -q "^$GEM_NAME ($GEM_VERSION)"; then
+            echo "Gem $GEM_NAME-$GEM_VERSION already on rubygems.org; skipping push (idempotent)."
+            exit 0
+          fi
           mkdir -p ~/.gem
           envsubst << 'EOF' > ~/.gem/credentials
           ---
@@ -133,6 +140,13 @@ jobs:
       - if: ${{ env.USE_OIDC == 'true' }}
         name: Build and push gem (OIDC)
         run: |
+          GEM_NAME=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).name")
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).version.to_s")
+          if gem list -r --exact -v "$GEM_VERSION" "$GEM_NAME" 2>/dev/null \
+               | grep -q "^$GEM_NAME ($GEM_VERSION)"; then
+            echo "Gem $GEM_NAME-$GEM_VERSION already on rubygems.org; skipping push (idempotent)."
+            exit 0
+          fi
           gem build *.gemspec
           gem push *.gem
 


### PR DESCRIPTION
https://github.com/metanorma/ci/pull/287

#287 prevented a real failure: `workflow_dispatch + next_version=patch`
publishes the gem in-job, then the resulting tag-push fires the auto-CI
chain which calls `gem push` again, and rubygems rejects with "Repushing
of gem versions is not allowed" (example linked in #287 body).

Side effect of skipping rake on tag-push: gems whose release flow
relies on `local rake release → tag-push → matrix → tests-passed →
do-release → release.yml gem-push` no longer have a publisher at all,
because the do-release dispatch was their only gem-push path. The
pre-publish matrix gate disappears as a consequence.

This PR keeps the intent of #287 (no double-publish) by addressing the
race at the gem-push step rather than at the test gate.

### Two changes

1. **`prepare-rake.yml`** — revert the `refs/tags/*` tag detection added
   in #287. Tag-push events again see `head_tag=""`, so `push_for_tag`
   evaluates false, and the matrix runs.

2. **`rubygems-release.yml`** — add an idempotency guard at the
   `gem push` step (both the API-key and OIDC paths): if the gem version
   already exists on rubygems.org, exit zero with a log line. The
   double-publish race becomes a no-op instead of an error.

### Behaviour after this PR

| Path | matrix gate | first publisher | second invocation |
|---|---|---|---|
| Local `rake release` | tag-push fires matrix; release only on green | release.yml via do-release chain | n/a |
| `workflow_dispatch + next_version=patch` | tag-push from in-job bump fires matrix in parallel | in-job rake release (existing) | release.yml via do-release → idempotent skip |
| `workflow_dispatch + next_version=skip` | tag-push fires matrix | in-job rake release | idempotent skip on second |
| `repository_dispatch / do-release` | n/a (this is the publisher path) | release.yml | n/a |

### Idempotency guard (concrete)

```bash
GEM_NAME=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).name")
GEM_VERSION=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).version.to_s")
if gem list -r --exact -v "$GEM_VERSION" "$GEM_NAME" 2>/dev/null \
     | grep -q "^$GEM_NAME ($GEM_VERSION)"; then
  echo "Gem $GEM_NAME-$GEM_VERSION already on rubygems.org; skipping push (idempotent)."
  exit 0
fi
```

The `lutaml/lutaml-model` failure in your #287 body would now succeed:
the first publish wins, the second sees the version on rubygems and
exits cleanly.

🤖
