### PR TITLE
refactor: test-gated release workflow with idempotent publish

### DIFF
--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -73,7 +73,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     needs: prepare
-    if: needs.prepare.outputs.push-for-tag != 'true'
 
     concurrency:
       group: '${{ github.workflow }}-${{ matrix.os }}-${{ matrix.ruby.version }}-${{ github.head_ref || github.ref_name }}'

--- a/.github/workflows/monorepo-rubygems-release.yml
+++ b/.github/workflows/monorepo-rubygems-release.yml
@@ -1,24 +1,3 @@
-# Reusable workflow for releasing an individual gem from a monorepo.
-#
-# Mirrors the single-gem rubygems-release.yml but adds monorepo support
-# via gem_name/gem_directory inputs that set the working directory.
-#
-# Usage (consumer repo creates a monorepo-release.yml that calls this):
-#   jobs:
-#     release:
-#       uses: metanorma/ci/.github/workflows/monorepo-rubygems-release.yml@main
-#       with:
-#         gem_name: coradoc-adoc    # sub-gem directory name, or "." for root gem
-#         gem_directory: .
-#         next_version: patch
-#       secrets:
-#         rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
-#         pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
-#
-# To override the build/publish command:
-#   with:
-#     release_command: bundle exec rake release
-
 name: monorepo-rubygems-release
 
 on:
@@ -38,10 +17,19 @@ on:
       next_version:
         description: >-
           Next release version. Possible values: x.y.z, major, minor,
-          patch (or pre|rc|etc).  Pass 'skip' to skip 'git tag' and do
-          'gem push' for the current version.
+          patch (or pre|rc|etc).  Pass 'skip' to skip version bump and
+          release the current gemspec version.
         required: true
         type: string
+      gated:
+        description: |
+          Defer gem publish until tests pass via the do-release chain.
+          - true (default): workflow_dispatch bumps+tags only; publish happens after
+            tests pass via repository_dispatch (do-release).
+          - false: workflow_dispatch bumps+tags+publishes immediately. The idempotent
+            guard handles the inevitable second push from do-release.
+        type: boolean
+        default: true
       release_command:
         description: >-
           Command to build and publish the gem. Defaults to
@@ -77,6 +65,12 @@ jobs:
     env:
       HAVE_PAT_TOKEN: ${{ secrets.pat_token != '' }}
       HAS_API_KEY: ${{ secrets.rubygems-api-key != '' }}
+      SHOULD_PUBLISH: >-
+        ${{
+          github.event_name == 'repository_dispatch' ||
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && inputs.gated == false)
+        }}
     defaults:
       run:
         working-directory: >-
@@ -104,6 +98,18 @@ jobs:
           working-directory: >-
             ${{ inputs.gem_directory }}/${{ inputs.gem_name }}
 
+      # ============ Gem identity ============
+      - name: Resolve gem identity
+        id: gem-identity
+        run: |
+          GEMSPEC=$(ls *.gemspec | head -1)
+          GEM_NAME=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').name")
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').version.to_s")
+          echo "name=${GEM_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "gemspec=${GEMSPEC}" >> "$GITHUB_OUTPUT"
+
+      # ============ Common git setup ============
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -112,14 +118,34 @@ jobs:
       - run: gem install gem-release
         working-directory: .
 
-      # Version bump
-      - if: >-
-          github.event_name == 'workflow_dispatch' &&
-          inputs.next_version != 'skip'
+      # ============ Version bump (workflow_dispatch only) ============
+      - name: Bump version
+        if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
         run: gem bump --version ${{ inputs.next_version }} --tag --push
+        working-directory: .
 
-      # Publish (API key path)
-      - if: ${{ env.HAS_API_KEY == 'true' }}
+      # ============ Auto-tag for skip mode (gated only) ============
+      - name: Tag current version (skip mode)
+        if: github.event_name == 'workflow_dispatch' && inputs.next_version == 'skip' && inputs.gated == true
+        run: |
+          TAG="v${{ steps.gem-identity.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; pushing to trigger test chain."
+          else
+            git tag "$TAG"
+          fi
+          git push origin "$TAG"
+        working-directory: .
+
+      # ============ Publish: API Key path ============
+      - name: Idempotency guard (API key)
+        if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY == 'true'
+        uses: metanorma/ci/gem-idempotent-push-guard-action@main
+        with:
+          gem-name: ${{ steps.gem-identity.outputs.name }}
+          gem-version: ${{ steps.gem-identity.outputs.version }}
+
+      - if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY == 'true' && env.skip_push != 'true'
         name: Publish to RubyGems (API key)
         env:
           RUBYGEMS_API_KEY: ${{ secrets.rubygems-api-key }}
@@ -132,28 +158,32 @@ jobs:
           chmod 0600 ~/.gem/credentials
           ${{ inputs.release_command }}
 
-      # Publish (OIDC path)
-      - if: ${{ env.HAS_API_KEY != 'true' }}
+      # ============ Publish: OIDC path ============
+      - if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY != 'true'
         name: Configure RubyGems credentials for Trusted Publishing
         uses: rubygems/configure-rubygems-credentials@v1.0.0
 
-      - if: ${{ env.HAS_API_KEY != 'true' && github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip' }}
-        run: gem bump --version ${{ inputs.next_version }} --tag --push
+      - name: Idempotency guard (OIDC)
+        if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY != 'true'
+        uses: metanorma/ci/gem-idempotent-push-guard-action@main
+        with:
+          gem-name: ${{ steps.gem-identity.outputs.name }}
+          gem-version: ${{ steps.gem-identity.outputs.version }}
 
-      - if: ${{ env.HAS_API_KEY != 'true' }}
+      - if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY != 'true' && env.skip_push != 'true'
         name: Build and push gem (OIDC)
         run: |
           gem build *.gemspec
           gem push *.gem
 
-      # Post-release event
+      # ============ Post-release event ============
       - name: Get current gem ref
         id: gem-tag-ref
-        run: |
-          GEM_VERSION=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).version.to_s")
-          echo "value=refs/tags/v${GEM_VERSION}" >> $GITHUB_OUTPUT
+        run: echo "value=refs/tags/v${{ steps.gem-identity.outputs.version }}" >> "$GITHUB_OUTPUT"
 
-      - uses: peter-evans/repository-dispatch@v3
+      - name: Dispatch release-passed
+        if: env.SHOULD_PUBLISH == 'true'
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.pat_token || github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/prepare-rake.yml
+++ b/.github/workflows/prepare-rake.yml
@@ -4,14 +4,11 @@ on:
   workflow_call:
     outputs:
       head-tag:
-        description: "Will be empty if there is not tag on HEAD"
+        description: "Will be empty if there is no tag on HEAD"
         value: ${{ jobs.prepare.outputs.head_tag }}
       foreign-pr:
         description: "Return yes if this is a foreign PR"
         value: ${{ jobs.prepare.outputs.foreign_pr }}
-      push-for-tag:
-        description: "Return true if duplicatet run on tag exists and this can be skipped"
-        value: ${{ jobs.prepare.outputs.push_for_tag }}
       matrix:
         description: "JSON string to be used in job.strategy.matrix"
         value: ${{ jobs.prepare.outputs.matrix }}
@@ -31,7 +28,6 @@ jobs:
       head_tag: ${{ steps.check.outputs.head_tag }}
       foreign_pr: ${{ steps.check.outputs.foreign_pr }}
       matrix: ${{ steps.matrix.outputs.value }}
-      push_for_tag: ${{ steps.push_for_tag.outputs.value }}
       default_ruby_version: ${{ steps.config.outputs.default_ruby_version }}
       public: ${{ steps.repo_status.outputs.public }}
     steps:
@@ -52,41 +48,20 @@ jobs:
           fi
           echo "foreign_pr=${fpr}"
           echo "head_tag=${tag}"
-          echo "foreign_pr=${fpr}" >> $GITHUB_OUTPUT
-          echo "head_tag=${tag}" >> $GITHUB_OUTPUT
-
-      - name: Push for tag
-        id: push_for_tag
-        shell: python
-        run: |
-          import os
-
-          event_name = '${{ github.event_name }}'
-          repository = '${{ github.repository }}'
-          head_tag = '${{ steps.check.outputs.head_tag }}'
-
-          excluded_events = ['pull_request', 'workflow_dispatch', 'repository_dispatch', 'cron']
-          excluded_repositories = ['metanorma/isodoc', 'metanorma/metanorma-standoc']
-
-          is_excluded_event = event_name in excluded_events
-          push_condition = event_name == 'push' and (head_tag == '' or repository in excluded_repositories)
-
-          result = str(not (is_excluded_event or push_condition)).lower()
-
-          print(f"The result is: {result}")
-          os.system(f"echo value={result} >> {os.environ['GITHUB_OUTPUT']}")
+          echo "foreign_pr=${fpr}" >> "$GITHUB_OUTPUT"
+          echo "head_tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - id: matrix
         run: |
           value="$(curl -L https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/ruby-matrix.json)"
           echo "Matrix JSON: ${value}"
-          echo "value=$(echo ${value} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          echo "value=$(echo ${value} | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
 
       - id: config
         run: |
           value="$(curl -L https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/config.json | jq .ruby.version -r)"
           echo "Default Ruby version: ${value}"
-          echo "default_ruby_version=${value}" >> $GITHUB_OUTPUT
+          echo "default_ruby_version=${value}" >> "$GITHUB_OUTPUT"
 
       - id: repo_status
         uses: metanorma/ci/gh-repo-status-action@main

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -6,9 +6,18 @@ on:
       next_version:
         description: |
           Next release version. Possible values: x.y.z, major, minor, patch (or pre|rc|etc).
-          Also, you can pass 'skip' to skip 'git tag' and do 'gem push' for the current version
+          Pass 'skip' to skip version bump and release the current gemspec version.
         required: true
         type: string
+      gated:
+        description: |
+          Defer gem publish until tests pass via the do-release chain.
+          - true (default): workflow_dispatch bumps+tags only; publish happens after
+            tests pass via repository_dispatch (do-release).
+          - false: workflow_dispatch bumps+tags+publishes immediately. The idempotent
+            guard handles the inevitable second push from do-release.
+        type: boolean
+        default: true
       event_name:
         description: 'deprecated github.event_name used instead'
         required: false
@@ -24,7 +33,7 @@ on:
         type: boolean
         default: true
       post_install:
-        description: 'comamnd to execute after bundle install'
+        description: 'command to execute after bundle install'
         required: false
         type: string
         default: ''
@@ -47,6 +56,7 @@ on:
         required: false
       pat_token:
         required: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -58,13 +68,15 @@ jobs:
       HAVE_PAT_TOKEN: ${{ secrets.pat_token != '' }}
       HAS_API_KEY: ${{ secrets.rubygems-api-key != '' }}
       USE_OIDC: ${{ secrets.rubygems-api-key == '' }}
+      SHOULD_PUBLISH: >-
+        ${{
+          github.event_name == 'repository_dispatch' ||
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && inputs.gated == false)
+        }}
     steps:
       - uses: actions/checkout@v6
         with:
-          # On `repository_dispatch` events (e.g. `do-release` fired by `tests-passed`
-          # for a `v*` tag), GitHub forces the workflow to run on the default branch.
-          # Honor the dispatched ref so we release the tagged commit, not whatever
-          # `main` happens to point at — required for releases off non-default branches.
           ref: ${{ github.event.client_payload.ref || github.ref }}
           submodules: ${{ inputs.submodules }}
           token: ${{ secrets.pat_token || github.token }}
@@ -85,15 +97,18 @@ jobs:
       - if: ${{ inputs.post_install != '' }}
         run: ${{ inputs.post_install }}
 
-      - name: Validate authentication method
+      # ============ Gem identity ============
+      - name: Resolve gem identity
+        id: gem-identity
         run: |
-          if [ "${{ env.HAS_API_KEY }}" != "true" ]; then
-            echo "Using OIDC Trusted Publishing (no rubygems-api-key provided)"
-            echo "Ensure Trusted Publishing is configured on RubyGems.org"
-            echo "See: https://guides.rubygems.org/trusted-publishing/"
-          fi
+          GEMSPEC=$(ls *.gemspec | head -1)
+          GEM_NAME=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').name")
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').version.to_s")
+          echo "name=${GEM_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "gemspec=${GEMSPEC}" >> "$GITHUB_OUTPUT"
 
-      # ============ Common setup for both paths ============
+      # ============ Common git setup ============
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -103,12 +118,35 @@ jobs:
       - name: Remove Gemfile.lock before bump
         run: rm -f Gemfile.lock
 
-      # ============ API Key Path ============
-      - if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip' && env.HAS_API_KEY == 'true'
+      # ============ Version bump (workflow_dispatch only) ============
+      - name: Bump version
+        if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
         run: gem bump --version ${{ inputs.next_version }} --tag --push
 
-      - if: ${{ env.HAS_API_KEY == 'true' }}
-        name: publish to rubygems.org (API Key)
+      # ============ Auto-tag for skip mode (gated only) ============
+      # When next_version=skip and gated=true, create and push a tag from the
+      # current gemspec version so the test chain fires and do-release publishes.
+      - name: Tag current version (skip mode)
+        if: github.event_name == 'workflow_dispatch' && inputs.next_version == 'skip' && inputs.gated == true
+        run: |
+          TAG="v${{ steps.gem-identity.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; pushing to trigger test chain."
+          else
+            git tag "$TAG"
+          fi
+          git push origin "$TAG"
+
+      # ============ Publish: API Key path ============
+      - name: Idempotency guard (API key)
+        if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY == 'true'
+        uses: metanorma/ci/gem-idempotent-push-guard-action@main
+        with:
+          gem-name: ${{ steps.gem-identity.outputs.name }}
+          gem-version: ${{ steps.gem-identity.outputs.version }}
+
+      - if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY == 'true' && env.skip_push != 'true'
+        name: Publish to rubygems.org (API Key)
         env:
           RUBYGEMS_API_KEY: ${{ secrets.rubygems-api-key }}
         run: |
@@ -120,36 +158,40 @@ jobs:
           chmod 0600 ~/.gem/credentials
           ${{ inputs.release_command }}
 
-      # ============ OIDC Trusted Publisher Path ============
-      - if: ${{ env.USE_OIDC == 'true' }}
+      # ============ Publish: OIDC Trusted Publisher path ============
+      - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true'
         name: Configure RubyGems credentials for Trusted Publishing
         uses: rubygems/configure-rubygems-credentials@v1.0.0
         with:
           role-to-assume: ${{ inputs.role_to_assume }}
 
-      - if: ${{ env.USE_OIDC == 'true' && github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip' }}
-        run: gem bump --version ${{ inputs.next_version }} --tag --push
+      - name: Idempotency guard (OIDC)
+        if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true'
+        uses: metanorma/ci/gem-idempotent-push-guard-action@main
+        with:
+          gem-name: ${{ steps.gem-identity.outputs.name }}
+          gem-version: ${{ steps.gem-identity.outputs.version }}
 
-      - if: ${{ env.USE_OIDC == 'true' }}
+      - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true' && env.skip_push != 'true'
         name: Build and push gem (OIDC)
         run: |
           gem build *.gemspec
-          gem push *.gem
+          mkdir -p pkg
+          mv *.gem pkg/
+          gem push pkg/*.gem
 
-      - if: ${{ env.USE_OIDC == 'true' }}
+      - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true' && env.skip_push != 'true'
         name: Wait for release to propagate
         run: gem exec rubygems-await pkg/*.gem
 
-      # ============ Common: Post-release event ============
-      # This workflow usually called via repository_dispatch or direct workflow_dispatch
-      # in both cases `github.ref` doesn't reflect real version so we calculate it from gemspecfile
-      - name: get current gem ref
+      # ============ Post-release event ============
+      - name: Get current gem ref
         id: gem-tag-ref
-        run: |
-          GEM_VERSION=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).version.to_s")
-          echo "value=refs/tags/v${GEM_VERSION}" >> $GITHUB_OUTPUT
+        run: echo "value=refs/tags/v${{ steps.gem-identity.outputs.version }}" >> "$GITHUB_OUTPUT"
 
-      - uses: peter-evans/repository-dispatch@v3
+      - name: Dispatch release-passed
+        if: env.SHOULD_PUBLISH == 'true'
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.pat_token || github.token }}
           repository: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,199 @@
+# Metanorma CI
+
+Shared GitHub Actions workflows and composite actions for building, testing, and releasing [Metanorma](https://metanorma.org) Ruby gems.
+
+## Reusable workflows
+
+### Testing
+
+| Workflow | Purpose |
+|----------|---------|
+| [`generic-rake.yml`](docs/generic-rake.md) | Run `bundle exec rake` across a Ruby version × OS matrix |
+| [`prepare-rake.yml`](docs/prepare-rake.md) | Tag detection, foreign-PR detection, test matrix resolution |
+| [`dependent-rake.yml`](.github/workflows/dependent-rake.yml) | Test downstream gems against the current gem |
+| [`monorepo-rake.yml`](.github/workflows/monorepo-rake.yml) | Test matrix for monorepo gems |
+| [`mn-processor-rake.yml`](.github/workflows/mn-processor-rake.yml) | Rake for Metanorma processor repos |
+| [`graphviz-rake.yml`](.github/workflows/graphviz-rake.yml) | Rake with Graphviz pre-installed |
+| [`inkscape-rake.yml`](.github/workflows/inkscape-rake.yml) | Rake with Inkscape pre-installed |
+| [`libreoffice-rake.yml`](.github/workflows/libreoffice-rake.yml) | Rake with LibreOffice pre-installed |
+| [`xml2rfc-rake.yml`](.github/workflows/xml2rfc-rake.yml) | Rake with xml2rfc pre-installed |
+
+### Releasing
+
+| Workflow | Purpose |
+|----------|---------|
+| [`rubygems-release.yml`](docs/rubygems-release.md) | Build and publish a gem to RubyGems.org |
+| [`monorepo-rubygems-release.yml`](docs/monorepo-rubygems-release.md) | Build and publish a monorepo gem to RubyGems.org |
+| [`ghpkg-release.yml`](.github/workflows/ghpkg-release.yml) | Publish a gem to GitHub Packages |
+
+### Other
+
+| Workflow | Purpose |
+|----------|---------|
+| [`sample-test.yml`](.github/workflows/sample-test.yml) | Test generated samples |
+| [`template-test.yml`](.github/workflows/template-test.yml) | Test template rendering |
+| [`sample-docker.yml`](.github/workflows/sample-docker.yml) | Generate samples in Docker |
+| [`build-sample-matrix.yml`](.github/workflows/build-sample-matrix.yml) | Build sample test matrix |
+| [`mn-processor-notify.yml`](.github/workflows/mn-processor-notify.yml) | Notify downstream processors |
+
+## Composite actions
+
+| Action | Purpose |
+|--------|---------|
+| [`tool-setup-action`](tool-setup-action/) | Install optional tools (inkscape, ghostscript, graphviz, etc.) |
+| [`gem-idempotent-push-guard-action`](docs/gem-idempotent-push-guard.md) | Skip gem push if version already exists on rubygems.org |
+| [`gh-rubygems-setup-action`](gh-rubygems-setup-action/) | Configure private GitHub Packages for RubyGems |
+| [`gh-repo-status-action`](gh-repo-status-action/) | Check if a repository is public or private |
+| [`gh-pages-status-action`](gh-pages-status-action/) | Check GitHub Pages deployment status |
+| [`choco-cache-action`](choco-cache-action/) | Cache Chocolatey packages on Windows |
+| [`inkscape-setup-action`](inkscape-setup-action/) | Install Inkscape |
+| [`ghostscript-setup-action`](ghostscript-setup-action/) | Install Ghostscript |
+| [`graphviz-setup-action`](graphviz-setup-action/) | Install Graphviz |
+| [`imagemagick-setup-action`](imagemagick-setup-action/) | Install ImageMagick |
+| [`libreoffice-setup-action`](libreoffice-setup-action/) | Install LibreOffice |
+| [`ffmpeg-setup-action`](ffmpeg-setup-action/) | Install FFmpeg |
+| [`exiftool-setup-action`](exiftool-setup-action/) | Install ExifTool |
+| [`xml2rfc-setup-action`](xml2rfc-setup-action/) | Install xml2rfc |
+| [`native-deps-action`](native-deps-action/) | List native library dependencies |
+| [`change-tmpdir-action`](change-tmpdir-action/) | Change temp directory |
+
+## Release workflow
+
+### Quick start
+
+```bash
+gh workflow run release.yml -f next_version=patch
+```
+
+### How it works
+
+The release is **test-gated by default**: the gem is only published after all tests pass.
+
+```
+gh workflow run release.yml -f next_version=patch
+  │
+  ▼
+Phase 1 — BUMP (workflow_dispatch → rubygems-release.yml)
+  Bumps version, creates git tag, pushes tag + commit.
+  Does NOT publish the gem.
+  │
+  ▼
+Phase 2 — TEST (tag push → rake.yml → generic-rake.yml)
+  Runs the full test matrix (Ruby versions × OSes).
+  │
+  ▼
+Phase 3 — PUBLISH (tests pass → do-release → rubygems-release.yml)
+  Checks out the tagged commit, builds gem, pushes to RubyGems.
+  An idempotent guard prevents double-publish.
+  Dispatches release-passed for downstream dependents.
+```
+
+### Bypassing the test gate
+
+```bash
+gh workflow run release.yml -f next_version=patch -f gated=false
+```
+
+Publishes immediately. The idempotent guard handles the second push from do-release.
+
+### Event chain
+
+```
+workflow_dispatch ──► rubygems-release.yml ──► gem bump --tag --push
+                                                       │
+                                                       ▼
+                                              tag push event
+                                                    ┌────┴──────────────────┐
+                                                    │                       │
+                                              rake.yml          (gated=false: publish
+                                                    │            immediately in Phase 1)
+                                                    ▼
+                                          generic-rake.yml
+                                          (test matrix runs)
+                                                    │
+                                        ┌───────────┴───────────┐
+                                        ▼                       ▼
+                                tests-passed dispatch    do-release dispatch
+                                (downstream repos        (triggers release.yml
+                                 notified)                → rubygems-release.yml
+                                                          as repository_dispatch)
+                                                                  │
+                                                                  ▼
+                                                          build + push gem
+                                                          (idempotent guard)
+                                                                  │
+                                                                  ▼
+                                                          release-passed dispatch
+```
+
+### Setting up a new repo
+
+Create two workflow files in `.github/workflows/`:
+
+**rake.yml** — test on every push, PR, and tag:
+
+```yaml
+name: rake
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ v* ]
+  pull_request:
+jobs:
+  rake:
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    secrets:
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+```
+
+**release.yml** — release on manual trigger or do-release event:
+
+```yaml
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: 'Next version (x.y.z, major, minor, patch, or skip)'
+        required: true
+        default: 'skip'
+  repository_dispatch:
+    types: [ do-release ]
+jobs:
+  release:
+    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    with:
+      next_version: ${{ github.event.inputs.next_version }}
+    secrets:
+      rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+```
+
+Set these repository secrets:
+- `METANORMA_CI_RUBYGEMS_API_KEY` — RubyGems API key for publishing
+- `METANORMA_CI_PAT_TOKEN` — GitHub PAT for cross-repo operations
+
+### Monorepo releases
+
+For repos containing multiple gems:
+
+```yaml
+jobs:
+  release:
+    uses: metanorma/ci/.github/workflows/monorepo-rubygems-release.yml@main
+    with:
+      gem_name: coradoc
+      next_version: patch
+    secrets:
+      rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+```
+
+### Workflow responsibilities
+
+| File | Responsibility |
+|------|---------------|
+| `prepare-rake.yml` | Detect tags, foreign PRs, resolve test matrix |
+| `generic-rake.yml` | Run test matrix, dispatch tests-passed + do-release |
+| `rubygems-release.yml` | Bump+tag (workflow_dispatch) or publish (repository_dispatch) |
+| `monorepo-rubygems-release.yml` | Same as rubygems-release.yml for monorepo gems |

--- a/docs/gem-idempotent-push-guard.md
+++ b/docs/gem-idempotent-push-guard.md
@@ -1,0 +1,32 @@
+# gem-idempotent-push-guard-action
+
+Composite action that checks if a gem version already exists on rubygems.org. If it does, sets `skip_push=true` in `$GITHUB_ENV` so subsequent push steps can be skipped.
+
+## Usage
+
+```yaml
+- uses: metanorma/ci/gem-idempotent-push-guard-action@main
+  with:
+    gem-name: ${{ steps.gem-identity.outputs.name }}
+    gem-version: ${{ steps.gem-identity.outputs.version }}
+
+- if: env.skip_push != 'true'
+  run: gem push *.gem
+```
+
+## Inputs
+
+| Input | Required | Description |
+|--------|----------|-------------|
+| `gem-name` | yes | Gem name (e.g. `metanorma`) |
+| `gem-version` | yes | Gem version (e.g. `1.2.3`) |
+
+## Outputs
+
+Sets `$GITHUB_ENV`:
+- `skip_push=true` — gem version already exists on rubygems.org
+- `skip_push=false` — gem version not found, safe to push
+
+## How it works
+
+Queries the RubyGems REST API (`/api/v1/versions/:name.json`) and checks if the version number appears in the response. Network errors cause the guard to pass (fails open) — the subsequent `gem push` will handle the error if the version already exists.

--- a/docs/generic-rake.md
+++ b/docs/generic-rake.md
@@ -1,0 +1,54 @@
+# generic-rake.yml
+
+Reusable workflow for running `bundle exec rake` across a Ruby version × OS test matrix.
+
+## Usage
+
+```yaml
+# .github/workflows/rake.yml
+name: rake
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ v* ]
+  pull_request:
+
+jobs:
+  rake:
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: inkscape,ghostscript
+    secrets:
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `tests-passed-event` | no | `tests-passed` | Event name dispatched after tests pass |
+| `release-event` | no | `do-release` | Event name dispatched when tests pass on a tag ref |
+| `before-setup-ruby` | no | `''` | Command to run before Ruby setup |
+| `after-setup-ruby` | no | `''` | Command to run after Ruby setup |
+| `shell` | no | `bash` | Shell for running commands |
+| `setup-inkscape` | no | `false` | Legacy — use `setup-tools` instead |
+| `setup-tools` | no | `''` | Comma-separated tools: `inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick` |
+| `submodules` | no | `recursive` | Checkout submodules: `true`, `false`, or `recursive` |
+| `private-fonts` | no | `false` | Enable private fonts via fontist-repo-setup |
+| `private-fonts-username` | no | `metanorma-ci` | Username for private fonts repository |
+| `choco-cache` | no | `false` | Cache Chocolatey on Windows |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `pat_token` | no | GitHub PAT for checkout and repository dispatch |
+
+## Behavior
+
+1. Calls `prepare-rake.yml` to resolve the test matrix.
+2. Runs `bundle exec rake` across all Ruby versions and OSes.
+3. On success, dispatches `tests-passed` event.
+4. If the ref is a tag (`refs/tags/v*`), also dispatches `do-release` event (triggers the release pipeline).
+
+The test matrix is defined in [ruby-matrix.json](../.github/workflows/ruby-matrix.json).

--- a/docs/monorepo-rubygems-release.md
+++ b/docs/monorepo-rubygems-release.md
@@ -1,0 +1,34 @@
+# monorepo-rubygems-release.yml
+
+Reusable workflow for building and publishing a single gem from a monorepo to RubyGems.org.
+
+Same architecture as `rubygems-release.yml` but with `gem_name` and `gem_directory` inputs for working directory support.
+
+## Usage
+
+```yaml
+jobs:
+  release:
+    uses: metanorma/ci/.github/workflows/monorepo-rubygems-release.yml@main
+    with:
+      gem_name: coradoc        # sub-directory containing the gem
+      gem_directory: .          # parent directory (default: '.')
+      next_version: patch
+    secrets:
+      rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `gem_name` | yes | — | Directory name of the gem relative to `gem_directory`. Use `.` for the root gem. |
+| `gem_directory` | no | `.` | Parent directory containing gem directories |
+| `next_version` | yes | — | Version bump type or `skip` |
+| `gated` | no | `true` | Defer publish until tests pass |
+| `release_command` | no | `gem build *.gemspec && gem push *.gem` | Build and publish command |
+| `submodules` | no | `true` | Checkout submodules |
+| `environment` | no | `''` | GitHub environment name |
+
+See [rubygems-release.md](rubygems-release.md) for details on `gated`, authentication, and behavior.

--- a/docs/prepare-rake.md
+++ b/docs/prepare-rake.md
@@ -1,0 +1,15 @@
+# prepare-rake.yml
+
+Reusable workflow that prepares the test environment: detects tags, foreign PRs, resolves the test matrix, and checks repository visibility.
+
+Called internally by `generic-rake.yml`. You should not need to call this directly.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `head-tag` | The tag on HEAD, or empty if none. Set for both branch pushes (via `git tag --points-at HEAD`) and tag pushes (via `github.ref_name`). |
+| `foreign-pr` | `"yes"` if this is a PR from a fork, `"no"` otherwise. |
+| `matrix` | JSON string for `job.strategy.matrix` (Ruby versions × OSes). |
+| `default-ruby-version` | Default Ruby version from [config.json](../.github/workflows/config.json). |
+| `public` | `"true"` if the repository is public. |

--- a/docs/rubygems-release.md
+++ b/docs/rubygems-release.md
@@ -1,0 +1,79 @@
+# rubygems-release.yml
+
+Reusable workflow for building and publishing a single Ruby gem to RubyGems.org.
+
+## Usage
+
+```yaml
+# .github/workflows/release.yml
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: 'Next version (x.y.z, major, minor, patch, or skip)'
+        required: true
+        default: 'skip'
+  repository_dispatch:
+    types: [ do-release ]
+
+jobs:
+  release:
+    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    with:
+      next_version: ${{ github.event.inputs.next_version }}
+    secrets:
+      rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `next_version` | yes | — | Version bump type (`patch`, `minor`, `major`, `x.y.z`) or `skip` to release the current gemspec version |
+| `gated` | no | `true` | Defer publish until tests pass via do-release chain. Set `false` to publish immediately. |
+| `release_command` | no | `bundle exec rake release` | Command to build and publish (API key auth only) |
+| `bundler_cache` | no | `true` | Run `bundle install` |
+| `post_install` | no | `''` | Command to run after `bundle install` |
+| `submodules` | no | `true` | Checkout submodules |
+| `role_to_assume` | no | — | OIDC Role ID for RubyGems Trusted Publishing |
+| `environment` | no | `''` | GitHub environment name (e.g., for required approvers) |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `rubygems-api-key` | no | RubyGems API key. If omitted, uses OIDC Trusted Publishing. |
+| `pat_token` | no | GitHub PAT for cross-repo operations and pushing tags. |
+
+## Authentication
+
+Two authentication paths:
+
+1. **API Key** (default when `rubygems-api-key` secret is set): Uses the API key to authenticate with RubyGems.
+2. **OIDC Trusted Publishing** (when no API key): Uses `rubygems/configure-rubygems-credentials` for keyless authentication.
+
+## Behavior
+
+### `gated: true` (default)
+
+```
+workflow_dispatch → bump + tag + push (no publish)
+  → tag push triggers rake.yml → tests → do-release → publish
+```
+
+### `gated: false`
+
+```
+workflow_dispatch → bump + tag + push + publish immediately
+  → tag push triggers rake.yml → tests → do-release → idempotent skip
+```
+
+### `next_version=skip`
+
+No version bump. Creates and pushes a tag from the current gemspec version so the test chain fires.
+
+## Events dispatched
+
+- `release-passed`: Dispatched after successful publish, for downstream notification.

--- a/gem-idempotent-push-guard-action/action.yml
+++ b/gem-idempotent-push-guard-action/action.yml
@@ -1,0 +1,21 @@
+name: 'Gem idempotent push guard'
+description: 'Check if a gem version already exists on rubygems.org. Sets skip_push=true env var to skip the subsequent push step.'
+inputs:
+  gem-name:
+    description: 'Gem name (e.g. metanorma)'
+    required: true
+  gem-version:
+    description: 'Gem version (e.g. 1.2.3)'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        if curl -sf "https://rubygems.org/api/v1/versions/${{ inputs.gem-name }}.json" \
+             | grep -q "\"number\":\"${{ inputs.gem-version }}\""; then
+          echo "::notice::Gem ${{ inputs.gem-name }}-${{ inputs.gem-version }} already on rubygems.org; skipping push (idempotent)."
+          echo "skip_push=true" >> "$GITHUB_ENV"
+        else
+          echo "skip_push=false" >> "$GITHUB_ENV"
+        fi


### PR DESCRIPTION
## Summary

Re-architect the release pipeline so that gem publishing is gated by tests, not suppressed at the test gate. Supersedes #288.

### The problem

Currently `workflow_dispatch(next_version=patch)` bumps, tags, pushes, AND publishes the gem in one job. The tag push then triggers `rake.yml` → tests → `do-release` → `rubygems-release.yml` again → second publish attempt → "Repushing of gem versions is not allowed."

PR #287 fixed this by skipping the test matrix on tag pushes. But that broke repos whose only publish path was through the `do-release` chain. PR #288 proposed adding an idempotent guard instead.

### The fix

Split `rubygems-release.yml` into two phases:
- **Phase 1 (workflow_dispatch)**: bump + tag + push. Does NOT publish.
- **Phase 2 (repository_dispatch / do-release)**: checkout tagged ref, build gem, push gem.

The test matrix gates the publish: tag push → tests → do-release → publish.

### Changes

| File | Change |
|------|--------|
| `rubygems-release.yml` | Split bump/publish phases. Add `gated` input (default true). Add idempotent guard. Extract gem identity step. Fix `rubygems-await` path bug. Handle `next_version=skip` with auto-tagging. |
| `prepare-rake.yml` | Remove `push_for_tag` and `excluded_repositories`. Tests always run. |
| `generic-rake.yml` | Remove `push-for-tag` skip condition. |
| `monorepo-rubygems-release.yml` | Align with same architecture. |
| `gem-idempotent-push-guard-action/` | New composite action — checks rubygems.org REST API. |
| `README.md` | Document release architecture, CLI commands, setup instructions. |

### CLI command

```bash
gh workflow run release.yml -f next_version=patch
```

### Event chain

```
workflow_dispatch → bump + tag + push
  → tag push triggers rake.yml → test matrix
    → tests pass → do-release → rubygems-release.yml → publish (idempotent)
```

### `gated` flag

- `gated: true` (default): publish deferred to do-release (test-gated).
- `gated: false`: publish immediately. Idempotent guard handles the race.

### Follow-up PRs needed

- `metanorma/isodoc`: add `tags: [v*]` to rake.yml, remove from release.yml
- `metanorma/metanorma-standoc`: same migration