### PR TITLE
Fix no-PAT release: publish immediately when relay cannot fire

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -13,7 +13,9 @@ on:
         description: |
           Defer gem publish until tests pass via the do-release chain.
           - true (default): workflow_dispatch bumps+tags only; publish happens after
-            tests pass via repository_dispatch (do-release).
+            tests pass via repository_dispatch (do-release). Requires a pat_token
+            to trigger downstream workflows. Falls back to immediate publish when
+            no pat_token is configured.
           - false: workflow_dispatch bumps+tags+publishes immediately. The idempotent
             guard handles the inevitable second push from do-release.
         type: boolean
@@ -72,7 +74,8 @@ jobs:
         ${{
           github.event_name == 'repository_dispatch' ||
           github.event_name == 'push' ||
-          (github.event_name == 'workflow_dispatch' && inputs.gated == false)
+          (github.event_name == 'workflow_dispatch' &&
+            (inputs.gated == false || secrets.pat_token == ''))
         }}
     steps:
       - uses: actions/checkout@v6
@@ -136,6 +139,18 @@ jobs:
             git tag "$TAG"
           fi
           git push origin "$TAG"
+
+      # ============ No-PAT fallback notice ============
+      # When gated=true but no PAT is configured, tag pushes made with
+      # GITHUB_TOKEN cannot trigger downstream workflows (GHA design).
+      # Degrade gracefully: publish immediately with idempotent guard.
+      - name: Notice — publishing immediately (no PAT)
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.gated == true &&
+          secrets.pat_token == ''
+        run: |
+          echo "::warning::No pat_token configured. Publishing immediately because the relay chain (bump → tag push → tests → do-release → publish) requires a PAT for tag pushes to trigger downstream workflows. To enable test-gated releases, configure a PAT token."
 
       # ============ Publish: API Key path ============
       - name: Idempotency guard (API key)

--- a/docs/rubygems-release.md
+++ b/docs/rubygems-release.md
@@ -32,7 +32,7 @@ jobs:
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `next_version` | yes | — | Version bump type (`patch`, `minor`, `major`, `x.y.z`) or `skip` to release the current gemspec version |
-| `gated` | no | `true` | Defer publish until tests pass via do-release chain. Set `false` to publish immediately. |
+| `gated` | no | `true` | Defer publish until tests pass via do-release chain. Set `false` to publish immediately. When `true` without `pat_token`, degrades to immediate publish (see PAT-free mode below). |
 | `release_command` | no | `bundle exec rake release` | Command to build and publish (API key auth only) |
 | `bundler_cache` | no | `true` | Run `bundle install` |
 | `post_install` | no | `''` | Command to run after `bundle install` |
@@ -45,7 +45,7 @@ jobs:
 | Secret | Required | Description |
 |--------|----------|-------------|
 | `rubygems-api-key` | no | RubyGems API key. If omitted, uses OIDC Trusted Publishing. |
-| `pat_token` | no | GitHub PAT for cross-repo operations and pushing tags. |
+| `pat_token` | no | GitHub PAT for pushing tags that trigger downstream workflows. Optional — see PAT-free mode. |
 
 ## Authentication
 
@@ -62,6 +62,23 @@ Two authentication paths:
 workflow_dispatch → bump + tag + push (no publish)
   → tag push triggers rake.yml → tests → do-release → publish
 ```
+
+Requires `pat_token` — pushes made with the default `GITHUB_TOKEN` cannot
+trigger downstream workflows (GHA design). See PAT-free mode below.
+
+### PAT-free mode (no `pat_token`)
+
+When `gated: true` but no `pat_token` is configured, the workflow degrades
+gracefully: it bumps, tags, pushes, **and publishes immediately** in the same
+job. The idempotent guard handles any eventual duplicate publish from a later
+`do-release` event.
+
+```
+workflow_dispatch → bump + tag + push + publish immediately
+```
+
+No PAT is required. Tests on main should already be green before triggering
+the release. To enable the full test-gated relay, configure a `pat_token`.
 
 ### `gated: false`
 


### PR DESCRIPTION
## Problem

When `gated=true` (default) and no `pat_token` is configured, tag pushes made with `GITHUB_TOKEN` cannot trigger downstream workflows (GHA design). The `do-release` relay never fires, so the gem is never published.

This broke fontist 3.0.8 release: bump+tag+push succeeded, but `rake.yml` never ran on the tag, `do-release` never dispatched, gem stuck at 3.0.7.

## Fix

Detect no-PAT case in `SHOULD_PUBLISH` and degrade gated mode to immediate publish with idempotent guard:

```yaml
# Before
(github.event_name == 'workflow_dispatch' && inputs.gated == false)

# After
(github.event_name == 'workflow_dispatch' &&
  (inputs.gated == false || secrets.pat_token == ''))
```

No PAT required. Works with just `GITHUB_TOKEN`.

## Behavior

| gated | PAT? | Publishes? | How |
|-------|------|------------|-----|
| true  | yes  | After tests | Full relay chain |
| true  | no   | Immediately | Idempotent guard handles duplicates |
| false | any  | Immediately | Unchanged |
