### PR TITLE
Fix: use env.HAVE_PAT_TOKEN instead of secrets in step if

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -148,7 +148,7 @@ jobs:
         if: >-
           github.event_name == 'workflow_dispatch' &&
           inputs.gated == true &&
-          secrets.pat_token == ''
+          env.HAVE_PAT_TOKEN == 'false'
         run: |
           echo "::warning::No pat_token configured. Publishing immediately because the relay chain (bump → tag push → tests → do-release → publish) requires a PAT for tag pushes to trigger downstream workflows. To enable test-gated releases, configure a PAT token."
 


### PR DESCRIPTION
Fixes the workflow parse error: `secrets` context is not available in step `if` conditions in nested reusable workflows. Use `env.HAVE_PAT_TOKEN` (already set at job level) instead.

Prerequisite for the fontist 3.0.8 release.