### PR TITLE
Route metanorma-org release.yml through metanorma/support wrapper

### DIFF
--- a/cimas-config/gh-actions/master/release.yml
+++ b/cimas-config/gh-actions/master/release.yml
@@ -14,10 +14,9 @@ on:
 
 jobs:
   release:
-    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    uses: metanorma/support/.github/workflows/release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
-      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/292

Routes the cimas-generated metanorma-org `release.yml` files through the new `metanorma/support` wrapper, bringing metanorma to release-flow parity with `relaton/support`, `fontist/support`, `lutaml/support`. This template was the last direct-caller into `metanorma/ci/rubygems-release.yml`.

## Changes to `cimas-config/gh-actions/master/release.yml`

- `uses:` → `metanorma/support/.github/workflows/release.yml@main` (was `metanorma/ci/.github/workflows/rubygems-release.yml@main`)
- Drop `pat_token` reference (the wrapper does not forward it, matching the convention used by `relaton/support`, `fontist/support`, `lutaml/support`)

## Downstream propagation

A cimas-sync wave on `metanorma/*` will then propagate this change to the 64 metanorma repos + 1 ammitto repo referencing this template.

The `master/release_wo_bundle_install.yml` variant (3 repos: metanorma, metanorma-utils, ...) is left unchanged in this PR; can be updated in a follow-up if desired.

🤖
