### PR TITLE
Resolve gem identity after bump so the new gem actually publishes

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -100,17 +100,6 @@ jobs:
       - if: ${{ inputs.post_install != '' }}
         run: ${{ inputs.post_install }}
 
-      # ============ Gem identity ============
-      - name: Resolve gem identity
-        id: gem-identity
-        run: |
-          GEMSPEC=$(ls *.gemspec | head -1)
-          GEM_NAME=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').name")
-          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').version.to_s")
-          echo "name=${GEM_NAME}" >> "$GITHUB_OUTPUT"
-          echo "version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "gemspec=${GEMSPEC}" >> "$GITHUB_OUTPUT"
-
       # ============ Common git setup ============
       - run: |
           git config user.name github-actions
@@ -125,6 +114,22 @@ jobs:
       - name: Bump version
         if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
         run: gem bump --version ${{ inputs.next_version }} --tag --push
+
+      # ============ Gem identity ============
+      # Resolved AFTER the bump so name/version/gemspec reflect the just-bumped
+      # version. If resolved before the bump, the idempotency guard, build, and
+      # tag-ref steps would all see the pre-bump (already-published) version,
+      # making the guard skip publishing the new gem while the new tag still
+      # gets pushed — a silently-unpublished release.
+      - name: Resolve gem identity
+        id: gem-identity
+        run: |
+          GEMSPEC=$(ls *.gemspec | head -1)
+          GEM_NAME=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').name")
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').version.to_s")
+          echo "name=${GEM_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "gemspec=${GEMSPEC}" >> "$GITHUB_OUTPUT"
 
       # ============ Auto-tag for skip mode (gated only) ============
       # When next_version=skip and gated=true, create and push a tag from the


### PR DESCRIPTION
## Problem

`rubygems-release.yml` resolved the gem version **before** the bump step. On the no-PAT immediate-publish fallback, the idempotency guard then checked the *pre-bump* (already-published) version, found it on RubyGems, and set `skip_push=true` — so the publish step was skipped. The bump step still created and pushed the **new tag**, leaving a tag with no corresponding gem while the job reported success.

Hit in the wild on `relaton/relaton-iso` 2.1.2 ([run](https://github.com/relaton/relaton-iso/actions/runs/27443085643)): tag `v2.1.2` was pushed, but RubyGems stayed at 2.1.1, with the log showing `Gem relaton-iso-2.1.1 already on rubygems.org; skipping push (idempotent).`

## Fix

Move the **Resolve gem identity** step to immediately **after** the **Bump version** step. Now the resolved name/version/gemspec — and therefore the idempotency guard, the build steps, and `gem-tag-ref` — all reflect the just-bumped version.

- **Bump mode** (`next_version != skip`): identity = bumped version → guard sees an unpublished version → gem is published. ✅
- **Skip mode** (`next_version == skip`): no bump, identity = current gemspec version → behavior unchanged. ✅

`git config` / `gem install gem-release` / `rm Gemfile.lock` still run before the bump, as required.

## Note on the fail-fast suggestion

The issue also floated failing the job when the guard skips a freshly-bumped version. I intentionally left that out: a skip is a *legitimate* idempotent outcome when re-running a release whose gem already landed (and for the `do-release` second push), so a hard fail would break re-runs. The reordering removes the actual cause.

Fixes #294
