### PR TITLE
Add metanorma-taste to cimas.yml flavour-gem set

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -131,6 +131,13 @@ repositories:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
+  metanorma-taste:
+    remote: ssh://git@github.com/metanorma/metanorma-taste
+    branch: main
+    files:
+      .rubocop.yml: gh-actions/master/.rubocop.yml
+      .github/workflows/release.yml: gh-actions/master/release.yml
+      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-un:
     remote: ssh://git@github.com/metanorma/metanorma-un
     branch: main


### PR DESCRIPTION
Adds `metanorma-taste:` back to `cimas-config/cimas.yml` with the standard flavour-gem file mapping (`.rubocop.yml`, `.github/workflows/release.yml`, `.github/workflows/automerge.yml`).

## Why

`metanorma-taste`'s `.github/workflows/release.yml` already carries the `# Auto-generated by Cimas: Do not edit it manually!` header, but the repo has no entry in `cimas-config/cimas.yml`. Most likely cause: taste was created during the cimas-revival hiatus and its workflow files were copy-pasted from another gem at creation time, never properly slotted into the cimas-managed set.

## Effect

The next `cimas sync` will regenerate taste's `.rubocop.yml`, `release.yml`, and `automerge.yml` from the master templates — same shape every other flavour gem (iho, m3aawg, cc, csa, vg, ribose, etc.) already has. In particular, taste's `release.yml` picks up the post-#293 wrapper routing through `metanorma/support`.

Insertion position is alphabetically-adjacent between `metanorma-iso` and `metanorma-un` to match the file's loose flavour-grouping convention.

🤖
