### PR TITLE
fix(monorepo-release): align with single-gem rubygems-release.yml

### DIFF
--- a/.github/workflows/monorepo-rubygems-release.yml
+++ b/.github/workflows/monorepo-rubygems-release.yml
@@ -25,7 +25,9 @@ on:
         description: |
           Defer gem publish until tests pass via the do-release chain.
           - true (default): workflow_dispatch bumps+tags only; publish happens after
-            tests pass via repository_dispatch (do-release).
+            tests pass via repository_dispatch (do-release). Requires a pat_token
+            to trigger downstream workflows. Falls back to immediate publish when
+            no pat_token is configured.
           - false: workflow_dispatch bumps+tags+publishes immediately. The idempotent
             guard handles the inevitable second push from do-release.
         type: boolean
@@ -37,11 +39,25 @@ on:
         required: false
         type: string
         default: 'gem build *.gemspec && gem push *.gem'
+      bundler_cache:
+        description: 'do bundle install'
+        required: false
+        type: boolean
+        default: true
+      post_install:
+        description: 'command to execute after bundle install'
+        required: false
+        type: string
+        default: ''
       submodules:
         description: Checkout submodules
         required: false
         type: boolean
         default: true
+      role_to_assume:
+        description: 'OIDC Role ID from RubyGems.org for Trusted Publishing (optional - auto-discovered if not provided)'
+        required: false
+        type: string
       environment:
         description: >-
           GitHub environment name for protection rules
@@ -65,11 +81,13 @@ jobs:
     env:
       HAVE_PAT_TOKEN: ${{ secrets.pat_token != '' }}
       HAS_API_KEY: ${{ secrets.rubygems-api-key != '' }}
+      USE_OIDC: ${{ secrets.rubygems-api-key == '' }}
       SHOULD_PUBLISH: >-
         ${{
           github.event_name == 'repository_dispatch' ||
           github.event_name == 'push' ||
-          (github.event_name == 'workflow_dispatch' && inputs.gated == false)
+          (github.event_name == 'workflow_dispatch' &&
+            (inputs.gated == false || secrets.pat_token == ''))
         }}
     defaults:
       run:
@@ -79,7 +97,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.client_payload.ref || github.ref }}
           submodules: ${{ inputs.submodules }}
+          token: ${{ secrets.pat_token || github.token }}
           fetch-depth: 0
 
       - if: github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
@@ -94,20 +114,12 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'
-          bundler-cache: true
+          bundler-cache: ${{ inputs.bundler_cache }}
           working-directory: >-
             ${{ inputs.gem_directory }}/${{ inputs.gem_name }}
 
-      # ============ Gem identity ============
-      - name: Resolve gem identity
-        id: gem-identity
-        run: |
-          GEMSPEC=$(ls *.gemspec | head -1)
-          GEM_NAME=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').name")
-          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').version.to_s")
-          echo "name=${GEM_NAME}" >> "$GITHUB_OUTPUT"
-          echo "version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "gemspec=${GEMSPEC}" >> "$GITHUB_OUTPUT"
+      - if: ${{ inputs.post_install != '' }}
+        run: ${{ inputs.post_install }}
 
       # ============ Common git setup ============
       - run: |
@@ -118,13 +130,36 @@ jobs:
       - run: gem install gem-release
         working-directory: .
 
+      - name: Remove Gemfile.lock before bump
+        run: rm -f Gemfile.lock
+
       # ============ Version bump (workflow_dispatch only) ============
+      # Runs in the gem's own subdirectory so gem-release sees exactly one
+      # gemspec. Running from the repo root would let gem-release traverse
+      # every subdirectory and pick the wrong gem (or multiple) in a monorepo.
       - name: Bump version
         if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
         run: gem bump --version ${{ inputs.next_version }} --tag --push
-        working-directory: .
+
+      # ============ Gem identity ============
+      # Resolved AFTER the bump so name/version/gemspec reflect the just-bumped
+      # version. If resolved before the bump, the idempotency guard, build, and
+      # tag-ref steps would all see the pre-bump (already-published) version,
+      # making the guard skip publishing the new gem while the new tag still
+      # gets pushed — a silently-unpublished release.
+      - name: Resolve gem identity
+        id: gem-identity
+        run: |
+          GEMSPEC=$(ls *.gemspec | head -1)
+          GEM_NAME=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').name")
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('${GEMSPEC}').version.to_s")
+          echo "name=${GEM_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "gemspec=${GEMSPEC}" >> "$GITHUB_OUTPUT"
 
       # ============ Auto-tag for skip mode (gated only) ============
+      # When next_version=skip and gated=true, create and push a tag from the
+      # current gemspec version so the test chain fires and do-release publishes.
       - name: Tag current version (skip mode)
         if: github.event_name == 'workflow_dispatch' && inputs.next_version == 'skip' && inputs.gated == true
         run: |
@@ -136,6 +171,18 @@ jobs:
           fi
           git push origin "$TAG"
         working-directory: .
+
+      # ============ No-PAT fallback notice ============
+      # When gated=true but no PAT is configured, tag pushes made with
+      # GITHUB_TOKEN cannot trigger downstream workflows (GHA design).
+      # Degrade gracefully: publish immediately with idempotent guard.
+      - name: Notice — publishing immediately (no PAT)
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.gated == true &&
+          env.HAVE_PAT_TOKEN == 'false'
+        run: |
+          echo "::warning::No pat_token configured. Publishing immediately because the relay chain (bump → tag push → tests → do-release → publish) requires a PAT for tag pushes to trigger downstream workflows. To enable test-gated releases, configure a PAT token."
 
       # ============ Publish: API Key path ============
       - name: Idempotency guard (API key)
@@ -158,23 +205,31 @@ jobs:
           chmod 0600 ~/.gem/credentials
           ${{ inputs.release_command }}
 
-      # ============ Publish: OIDC path ============
-      - if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY != 'true'
+      # ============ Publish: OIDC Trusted Publisher path ============
+      - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true'
         name: Configure RubyGems credentials for Trusted Publishing
         uses: rubygems/configure-rubygems-credentials@v1.0.0
+        with:
+          role-to-assume: ${{ inputs.role_to_assume }}
 
       - name: Idempotency guard (OIDC)
-        if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY != 'true'
+        if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true'
         uses: metanorma/ci/gem-idempotent-push-guard-action@main
         with:
           gem-name: ${{ steps.gem-identity.outputs.name }}
           gem-version: ${{ steps.gem-identity.outputs.version }}
 
-      - if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY != 'true' && env.skip_push != 'true'
+      - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true' && env.skip_push != 'true'
         name: Build and push gem (OIDC)
         run: |
           gem build *.gemspec
-          gem push *.gem
+          mkdir -p pkg
+          mv *.gem pkg/
+          gem push pkg/*.gem
+
+      - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true' && env.skip_push != 'true'
+        name: Wait for release to propagate
+        run: gem exec rubygems-await pkg/*.gem
 
       # ============ Post-release event ============
       - name: Get current gem ref

--- a/docs/monorepo-rubygems-release.md
+++ b/docs/monorepo-rubygems-release.md
@@ -27,8 +27,11 @@ jobs:
 | `gem_directory` | no | `.` | Parent directory containing gem directories |
 | `next_version` | yes | — | Version bump type or `skip` |
 | `gated` | no | `true` | Defer publish until tests pass |
-| `release_command` | no | `gem build *.gemspec && gem push *.gem` | Build and publish command |
+| `release_command` | no | `gem build *.gemspec && gem push *.gem` | Build and publish command (API key path only) |
+| `bundler_cache` | no | `true` | Run `bundle install` |
+| `post_install` | no | `''` | Command to run after `bundle install` |
 | `submodules` | no | `true` | Checkout submodules |
+| `role_to_assume` | no | — | OIDC Role ID for RubyGems Trusted Publishing (auto-discovered if omitted) |
 | `environment` | no | `''` | GitHub environment name |
 
 See [rubygems-release.md](rubygems-release.md) for details on `gated`, authentication, and behavior.


### PR DESCRIPTION
## Problem

The monorepo release workflow has been silently producing tags with no corresponding published gems. coradoc had `v2.0.17`/`v2.0.19` orphan bumps on `main` with no tags, and rubygems shows multiple published versions whose tags are missing.

Root cause: the workflow resolves **gem identity BEFORE the version bump**, so on the no-PAT immediate-publish fallback the idempotency guard sees the pre-bump (already-published) version, sets `skip_push=true`, and the new gem never publishes — while the new tag still gets pushed.

This is the same bug fixed in single-gem `rubygems-release.yml` by 34b95a0 (`Resolve gem identity after bump so new gem actually publishes`). The single-gem workflow is now correct; this PR mirrors those fixes onto the monorepo variant.

## Critical fix

- Move `Resolve gem identity` to **after** `Bump version` so the idempotency guard, build, and tag-ref steps see the just-bumped version.

## Other alignments with rubygems-release.yml

- Add no-PAT fallback to `SHOULD_PUBLISH` (publish immediately when `gated` but no `pat_token`, since `GITHUB_TOKEN` tag pushes can't trigger the do-release relay).
- Add explicit `Notice — publishing immediately (no PAT)` warning step.
- Add `Remove Gemfile.lock before bump` step.
- Add `rubygems-await` propagation after OIDC push; move gem to `pkg/`.
- `Bump version` now runs in the gem's own subdirectory (no `working-directory: .` override), so gem-release sees exactly one gemspec. Previously it traversed every subdirectory and picked the wrong gem (or multiple) in a monorepo.
- Add `bundler_cache`, `post_install`, `role_to_assume` inputs to match the single-gem surface.
- Honor `github.event.client_payload.ref` on checkout so do-release works off non-default branches.
- Pass `pat_token || github.token` to checkout for private submodule access.

## Docs

Updates `docs/monorepo-rubygems-release.md` to list the new inputs.

## Verification

Local YAML syntax validated. Behavior parity verified by diffing against `rubygems-release.yml`. End-to-end release verification pending merge + a real release run.

Resolves the orphan-bump class of bugs seen in metanorma/coradoc (and likely other monorepo users of this workflow).