### PR TITLE
feat(monorepo-release): add version_file input for non-standard version paths

### DIFF
--- a/.github/workflows/monorepo-rubygems-release.yml
+++ b/.github/workflows/monorepo-rubygems-release.yml
@@ -39,6 +39,15 @@ on:
         required: false
         type: string
         default: 'gem build *.gemspec && gem push *.gem'
+      version_file:
+        description: >-
+          Path (relative to the gem directory) to the version file gem-release
+          should bump. Leave empty for the standard `lib/<gem_name>/version.rb`
+          layout. Set this when the version file lives at a non-standard path
+          (e.g. `lib/foo/bar/version.rb` for a gem named `foo`).
+        required: false
+        type: string
+        default: ''
       bundler_cache:
         description: 'do bundle install'
         required: false
@@ -137,9 +146,16 @@ jobs:
       # Runs in the gem's own subdirectory so gem-release sees exactly one
       # gemspec. Running from the repo root would let gem-release traverse
       # every subdirectory and pick the wrong gem (or multiple) in a monorepo.
+      # When version_file is set, pass --file so gem-release can locate
+      # non-standard version paths (e.g. lib/foo/bar/version.rb for gem "foo").
       - name: Bump version
         if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
-        run: gem bump --version ${{ inputs.next_version }} --tag --push
+        run: |
+          if [ -n "${{ inputs.version_file }}" ]; then
+            gem bump --version ${{ inputs.next_version }} --tag --push --file '${{ inputs.version_file }}'
+          else
+            gem bump --version ${{ inputs.next_version }} --tag --push
+          fi
 
       # ============ Gem identity ============
       # Resolved AFTER the bump so name/version/gemspec reflect the just-bumped

--- a/docs/monorepo-rubygems-release.md
+++ b/docs/monorepo-rubygems-release.md
@@ -28,6 +28,7 @@ jobs:
 | `next_version` | yes | — | Version bump type or `skip` |
 | `gated` | no | `true` | Defer publish until tests pass |
 | `release_command` | no | `gem build *.gemspec && gem push *.gem` | Build and publish command (API key path only) |
+| `version_file` | no | — | Path to version file (relative to gem dir) when non-standard; bypass with empty for `lib/<gem>/version.rb` |
 | `bundler_cache` | no | `true` | Run `bundle install` |
 | `post_install` | no | `''` | Command to run after `bundle install` |
 | `submodules` | no | `true` | Checkout submodules |


### PR DESCRIPTION
## Problem

The coradoc monorepo's satellite gems (`coradoc-adoc`, `coradoc-html`, `coradoc-markdown`, `coradoc-docx`) all have version files at non-standard paths:

- `coradoc-adoc` → `lib/coradoc/asciidoc/version.rb` (not `lib/coradoc_adoc/version.rb`)
- `coradoc-html` → `lib/coradoc/html/version.rb`
- `coradoc-markdown` → `lib/coradoc/markdown/version.rb`
- `coradoc-docx` → `lib/coradoc/docx/version.rb`

`gem-release` auto-detects the version file by convention `lib/<gem_name>/version.rb`, which fails for these gems:

```
Ignoring coradoc-adoc. Version file ? not found. Aborting.
```

This blocked the coradoc-adoc 2.0.10 patch release (run 27867283902).

## Fix

Add a `version_file` input (relative to the gem directory) that, when set, is passed as `--file` to `gem bump`. Empty by default to preserve current behavior for gems with the standard layout.

When `version_file` is set, pass `--file` so gem-release can locate non-standard version paths. When empty, fall back to gem-release's auto-detection.

Verified locally with coradoc-adoc: `gem bump --version patch --file lib/coradoc/asciidoc/version.rb` correctly bumps `Coradoc::AsciiDoc::VERSION`.

## Usage

Callers with non-standard version paths pass `version_file`:

- gem_name: coradoc-adoc
- gem_directory: .
- version_file: lib/coradoc/asciidoc/version.rb
- next_version: patch

Gems with the standard `lib/<gem_name>/version.rb` layout leave it empty.
