### PR TITLE
Add patches: ruby_version block to centralise required_ruby_version across gemspecs

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -1663,3 +1663,15 @@ groups:
   - barcode4j
   # convert
   - coradoc-oscal
+
+# Regex find/replace patches applied at sync time to files that already
+# exist in target repos (gemspecs, etc.) — the centralised counterpart
+# to the CI-runtime ruby-matrix.json. See metanorma/ci#274 for context
+# and metanorma/cimas#38 for the patches mechanism itself.
+patches:
+  ruby_version:
+    files:
+      - "*.gemspec"
+    find: 'spec\.required_ruby_version\s*=.*'
+    replace: 'spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")'
+    groups: [processor, pubid, model, tools, metanorma, plugins]


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/274

## What this PR adds

A new top-level `patches:` block in `cimas-config/cimas.yml`:

```yaml
patches:
  ruby_version:
    files:
      - "*.gemspec"
    find: 'spec\.required_ruby_version\s*=.*'
    replace: 'spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")'
    groups: [processor, pubid, model, tools, metanorma, plugins]
```

This uses the `patches:` mechanism added in metanorma/cimas#38 to bulk-edit `spec.required_ruby_version` in every `*.gemspec` belonging to the listed groups when `cimas sync` runs.

## Why now

#273 ("Drop Ruby 3.2 from CI matrix, add 3.3") deliberately did **not** propagate to gemspecs, on the grounds that the CI runtime matrix is centralised via `ruby-matrix.json` and propagation isn't needed for GHA. That stance is correct for **CI** — `prepare-rake.yml:56` `curl`s the JSON at runtime, so editing one file moves the floor for every downstream `rake.yml` consumer of `generic-rake.yml@main`.

But there is a separate surface that the central-matrix doesn't reach:

- **Rubocop's `TargetRubyVersion`** defaults to whatever the gemspec declares as `required_ruby_version`. If a gemspec still says `>= 2.7` (or has no declaration at all), rubocop lints against the wrong Ruby and produces inconsistent results between local dev and CI — particularly for cops gated on Ruby version (`Style/HashSyntax`, `Lint/AmbiguousOperatorPrecedence`, etc.).
- **`bundle install` on downstream consumers** doesn't get a clean "this gem requires Ruby ≥ 3.3" error on Ruby 3.2 if the gemspec has no `required_ruby_version`; it'll silently install and then break at runtime.

The follow-up note in cimas#38 itself named this exact target:

> After merge + release: PR against `metanorma/ci` to add the real `patches:` block for `ruby_version` to `cimas-config/cimas.yml`.

Full rationale on the parent issue: https://github.com/metanorma/ci/issues/274#issuecomment-4769777935

## Scope

Affects gemspecs in 6 groups (verified against `groups:` section of current `cimas.yml`):

| Group | Members |
|---|---|
| `processor` | 20 metanorma flavour processors (`metanorma-cli`, `metanorma-csa`, `metanorma-cc`, …, `metanorma-plateau`) |
| `pubid` | 12 pubid identifier libraries (`pubid`, `pubid-core`, `pubid-{ieee,iso,iec,bsi,cen,jis,itu,ccsds,nist,plateau}`) |
| `model` | 20 metanorma model gems (`metanorma-model-*`, `basicdoc-models`, `metanorma-requirements-models`) |
| `tools` | `html2doc`, `rfc2md`, `mn2pdf-ruby`, `mn2sts-ruby`, `stepmod2mn`, `iso690render`, `csa-ccm-tools`, `reverse_adoc`, `tex2mn`, `isodoc`, `mnconvert-ruby`, `sts-ruby`, `rfcxml`, `niso-jats` |
| `metanorma` | `metanorma`, `metanorma-cli`, `metanorma-core`, `metanorma-registry`, `metanorma-utils` |
| `plugins` | `metanorma-plugin-lutaml`, `metanorma-plugin-datastruct` |

Roughly 60-70 gemspec edits will land as per-repo PRs when `cimas sync` runs.

## What this PR does NOT touch

- `infrastructure` group (`cimas`, `ci`, `lapidist`, `oss-guides`) — not gemspec-installed by end users.
- `site`, `samples`, `docs`, `templates`, `setup`, `choco`, `homebrew`, `iso`, `apps`, `snap`, `asciirfc`, `data`, `fetcher`, `java`, `style` — not Ruby gems.

## ⚠️ cimas release status — read before running sync

`metanorma/cimas#38` shipped the `patches:` mechanism on `metanorma/cimas` `main` and bumped `lib/cimas/version.rb` to `0.3.0`, but **`v0.3.0` has not been released as a gem yet** (latest tag is `v0.2.0`).

When this PR merges and the sync wave runs, cimas must execute from source (`bundle exec cimas` from a `metanorma/cimas` `main` checkout), not from a rubygems install — or a `v0.3.0` release needs to be cut first. A `cimas 0.2.0` invocation will not see the `patches:` key and the gemspec edits will silently be skipped.

## Verification done

- `ruby -ryaml -e 'YAML.load_file("cimas-config/cimas.yml")'` parses cleanly with all four top-level keys (`settings`, `repositories`, `groups`, `patches`) and regex/replace strings intact.
- Group names verified against the `groups:` section — all six referenced groups exist with the expected memberships.
- `find` regex `spec\.required_ruby_version\s*=.*` is greedy and replaces the whole line including any trailing comment; this matches the cimas#38 example and is the intended shape.

🤖
