### PR TITLE
Remove archived repos (metanorma-vg, metanorma-tutorial) from cimas.yml

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -58,13 +58,6 @@ repositories:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-vg:
-    remote: ssh://git@github.com/metanorma/metanorma-vg
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-ribose:
     remote: ssh://git@github.com/metanorma/metanorma-ribose
     branch: main
@@ -873,12 +866,6 @@ repositories:
   iso-tc184-sc4-boilerplate:
     remote: ssh://git@github.com/metanorma/iso-tc184-sc4-boilerplate
     branch: main
-    files:
-      .github/workflows/docker.yml: gh-actions/samples/public-docker.yml
-      .github/workflows/generate.yml: gh-actions/samples/public-generate.yml
-  metanorma-tutorial:
-    remote: ssh://git@github.com/metanorma/metanorma-tutorial
-    branch: master
     files:
       .github/workflows/docker.yml: gh-actions/samples/public-docker.yml
       .github/workflows/generate.yml: gh-actions/samples/public-generate.yml


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Removes two archived (and therefore read-only) repositories from `cimas-config/cimas.yml`:

- `metanorma-vg` (archived)
- `metanorma-tutorial` (archived)

Both repos rejected the `cimas-sync-2026-06-24` push attempt earlier today with `ERROR: This repository was archived so it is read-only`. Keeping them in `cimas.yml` means every future sync wave logs the same archive errors and partially clutters the diff output. Removing them is no-op behaviourally (they were unpushable anyway) and tightens cimas's effective coverage to the live repos.

## Out of scope (flagged for separate decision)

The same sync wave surfaced three additional repos under `metanorma/` that rejected pushes — but with **permission-denied** rather than archive errors:

- `atmospheric` — `ERROR: Permission to metanorma/atmospheric.git denied to opoudjis`
- `sample-ogc-discussion-paper` — same shape
- `ogc-modspec` — same shape

These are different from archived: the repos are live, but opoudjis (the user driving the wave) lacks push permission. The right fix is one of: add opoudjis as a collaborator (if the team wants cimas to manage them), reassign cimas-side ownership to whoever does have push, or remove them from `cimas.yml` if they're not actually meant to be cimas-managed. Not touching them in this PR — they need a per-repo decision.

🤖
