### PR TITLE
Fix cimas model Makefile: add -t png to lutaml lml generate

### DIFF
--- a/cimas-config/gh-actions/model/Makefile
+++ b/cimas-config/gh-actions/model/Makefile
@@ -18,7 +18,7 @@ PNG := $(patsubst views/%.lutaml,images/%.png,$(SRC))
 all: $(PNG)
 
 images/%.png: views/%.lutaml
-	lutaml lml generate $< -o $@
+	lutaml lml generate $< -o $@ -t png
 
 views/%.lutaml: models/%.wsd | views
 	lutaml-wsd2uml $< > $@


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/281
Refs https://github.com/metanorma/ci/issues/302

## Summary

Adds the missing `-t png` flag to the `images/%.png` recipe in `cimas-config/gh-actions/model/Makefile`. Without it, current lutaml (0.10.x) writes Graphviz dot source text into the `.png` files instead of rendering them; the `make all` invocation still exits 0 (green CI), but the resulting `images/*.png` files are malformed (`file` reports them as `ASCII/HTML text` rather than `PNG image data`).

The fix is one line:

```diff
 images/%.png: views/%.lutaml
-	lutaml lml generate $< -o $@
+	lutaml lml generate $< -o $@ -t png
```

Verified by sibling instance against `basicdoc-models`: with `-t png` → real PNG (`PNG image data, 2286 x 811, 8-bit/color RGB`); without → `ASCII/HTML text`.

## Why this surfaced now

The Makefile template was updated for the lutaml 0.10.18 CLI change in #281 / #282 (merged earlier today). Tonight's cimas sync wave (2026-06-24, the run produced the 99-PR flood) propagated the updated template to the ~13 model repos that take it. Several of those wave PRs auto-merged before anyone noticed `make all` was silently writing text into `.png` files — so the buggy Makefile is now on `main` in: `basicdoc-models`, `metanorma-model-{itu, cc, csa, iho, bipm, ieee, ribose, bsi, m3aawg, rsd, m3d}`, `metanorma-requirements-models`.

This PR fixes the template at source. The next cimas sync wave will then catch up those 13 repos' on-main Makefiles automatically; per the user's call, no per-repo follow-up PRs needed since these model repos don't see frequent active development between cimas runs.

## Connection to #302

This is exactly the "make exits 0 but output is malformed" pattern that motivated [#302](https://github.com/metanorma/ci/issues/302)'s "green means published" / downstream-cascade-observability work. The CI cannot tell whether the `make` recipe produced real PNGs or text-misnamed-as-PNGs without an explicit content-type assertion downstream of `make all`. Worth considering — as a small companion fix in some later iteration — adding a check like `file images/*.png | grep -q "PNG image data"` (or equivalent) to the model-repo CI so this class of bug fails CI rather than passing silently.

🤖
