### PR TITLE
Add verify-images target to model Makefile to catch silent-green PNG output bugs

### DIFF
--- a/cimas-config/gh-actions/model/Makefile
+++ b/cimas-config/gh-actions/model/Makefile
@@ -15,7 +15,7 @@ endif
 
 PNG := $(patsubst views/%.lutaml,images/%.png,$(SRC))
 
-all: $(PNG)
+all: $(PNG) verify-images
 
 images/%.png: views/%.lutaml
 	lutaml lml generate $< -o $@ -t png
@@ -26,7 +26,35 @@ views/%.lutaml: models/%.wsd | views
 views:
 	mkdir views
 
+# Defensive content-type check. The lutaml CLI happily writes Graphviz dot
+# source into a .png output path when the wrong flag is passed (the bug
+# fixed by metanorma/ci#303 — text content in files named *.png, with
+# `make all` still exiting 0). This target asserts each generated PNG
+# actually starts with the PNG magic bytes, so the same class of bug fails
+# CI loudly instead of passing silently. See metanorma/ci#302 for the
+# broader "make-exits-0-but-output-malformed" pattern.
+ifeq ($(OS),Windows_NT)
+verify-images:
+	@echo "verify-images: skipped on Windows (file(1) not standard)"
+else
+verify-images: $(PNG)
+	@count=0; bad=0; \
+	for f in $(PNG); do \
+	  if [ -z "$$f" ]; then continue; fi; \
+	  count=$$((count+1)); \
+	  if ! file -b "$$f" | grep -q "^PNG image data"; then \
+	    echo "ERROR: $$f is not a valid PNG (file -b reports: $$(file -b "$$f"))" >&2; \
+	    bad=$$((bad+1)); \
+	  fi; \
+	done; \
+	if [ $$bad -gt 0 ]; then \
+	  echo "verify-images: $$bad of $$count file(s) failed PNG content check" >&2; \
+	  exit 1; \
+	fi; \
+	echo "verify-images: $$count PNG file(s) verified"
+endif
+
 clean:
 	$(RM) images/*.png
 
-.PHONY: clean
+.PHONY: clean verify-images all


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/302

## Summary

Adds a `verify-images` target to the cimas model Makefile template that asserts every generated `images/*.png` actually starts with PNG magic bytes (`file -b "$f"` matches `^PNG image data`). `make all` now depends on it, so the model-build CI fails loudly on the entire class of "tool wrote into the right path but the bytes are wrong" bugs — the same class that [`metanorma/ci#303`](https://github.com/metanorma/ci/pull/303) fixed one symptom of two days ago.

## Why

`metanorma/ci#303` fixed a specific instance of this class — `lutaml lml generate` without `-t png` writes Graphviz dot source text into `.png` files, while `make all` happily exits 0 because the recipe succeeded at the process-exit-code level. CI was green for every model repo even though their generated images were not images.

That was one tool, one missing flag. The class is bigger: any future drift in a generator (lutaml version bump that changes default output, a typo in a future Makefile flag, a wrong template anywhere in the model CI chain) would reproduce the same silent-green pattern.

This change closes the silent-green door at the model-build layer. Recommended in #302's observation 2 ("downstream cascade as a first-class observable step") under the broader release-pipeline observability work; this PR is the small concrete instance for the model-build sub-chain.

## Implementation

```makefile
all: $(PNG) verify-images

# ... (existing recipes unchanged)

ifeq ($(OS),Windows_NT)
verify-images:
	@echo "verify-images: skipped on Windows (file(1) not standard)"
else
verify-images: $(PNG)
	@count=0; bad=0; \
	for f in $(PNG); do \
	  if [ -z "$$f" ]; then continue; fi; \
	  count=$$((count+1)); \
	  if ! file -b "$$f" | grep -q "^PNG image data"; then \
	    echo "ERROR: $$f is not a valid PNG (file -b reports: $$(file -b "$$f"))" >&2; \
	    bad=$$((bad+1)); \
	  fi; \
	done; \
	if [ $$bad -gt 0 ]; then \
	  echo "verify-images: $$bad of $$count file(s) failed PNG content check" >&2; \
	  exit 1; \
	fi; \
	echo "verify-images: $$count PNG file(s) verified"
endif
```

- `all: $(PNG) verify-images` makes verification part of the default flow. Make's dep graph ensures all PNGs are built before verify-images runs.
- `verify-images: $(PNG)` makes the target itself runnable standalone (`make verify-images` after `make all` works).
- Windows path is a no-op `@echo` since `file(1)` isn't standard there. The bug class catches just as well on the Linux/macOS matrix entries; Windows-side regressions would still surface there. (Windows verification could be added later via a PowerShell magic-bytes check if there's appetite — out of scope here.)
- POSIX-portable bash inside the recipe (no `[[ ]]`, no bash-isms; works on the macOS runner's older bash 3.2 just as it does on Linux's bash 5.x).

## Verification

Smoke-tested locally against `/tmp/mock-model/` with a fake `views/foo.lutaml` and three planted `images/foo.png` contents:

- **PNG-magic-bytes-only (8 bytes, header but no body)**: `file -b` reports `data` → REJECTED ✅
- **`echo "Not a PNG" > images/foo.png`**: `file -b` reports `ASCII text` → REJECTED ✅
- **Real lutaml output** (verified by the sibling instance during the #303 work — actual `lutaml lml generate ... -t png` output): `file -b` reports `PNG image data, ... bit/color RGB, ...` → MATCHED ✅

`make verify-images` exits non-zero on any failure; `make all` propagates the failure naturally.

## Propagation

This change lands in the master template; the ~14 model repos that take it pick up the new `verify-images` step on their next cimas sync wave. Existing model-repo Makefiles on `main` still ride the older template until then — no migration ceremony needed.

## Out of scope

A Windows-side magic-bytes equivalent (e.g., PowerShell `[System.IO.File]::ReadAllBytes($f)[0..7]` compared to the PNG signature). Would broaden coverage; left as a follow-up if a Windows-specific regression actually surfaces.

🤖
