### PR TITLE
Drop dormant sample-ogc-discussion-paper from cimas.yml

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -883,13 +883,6 @@ repositories:
       .github/workflows/docker.yml:
         if_public: gh-actions/samples/public-docker.yml
         if_private: gh-actions/samples/private-docker.yml.erb
-  sample-ogc-discussion-paper:
-    remote: ssh://git@github.com/metanorma/sample-ogc-discussion-paper
-    branch: main
-    files:
-      .github/workflows/docker.yml:
-        if_public: gh-actions/samples/public-docker.yml
-        if_private: gh-actions/samples/private-docker.yml.erb
   ietf-rfc-3339:
     remote: ssh://git@github.com/metanorma/ietf-rfc-3339
     branch: master


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/pull/301

## Summary

Removes the dormant `sample-ogc-discussion-paper` entry from `cimas-config/cimas.yml`. Same shape and rationale as `#301` (archived-repo cleanup), one tier softer — this repo isn't archived, just inactive for ~3 years.

## Why

Surfaced during the 2026-06-24 cimas sync wave: `sample-ogc-discussion-paper` is one of three repos whose push from the wave failed with permission denied. Investigation (read-only `gh api`):

- Last push: **2023-10-02** (~3 years).
- Recent committers: `@abunashir` and `@ronaldtse` (last commits 2021-01).
- Description: literally "Sample".
- Not archived; just nobody works on it.

Cimas attempting to sync workflows into it on every wave is pure noise — no CI runs against it, no docs build consumes it, and the perm-denied push produces a `[WARNING]` line every sync. Removing the entry cleans up the wave log and reduces the cimas-managed surface by one no-op repo.

## Out of scope

Two other repos also returned perm-denied on the wave; treated separately:

- **`atmospheric`** — actively maintained by @ronaldtse (last push 2026-04-23). In scope of [`#304`](https://github.com/metanorma/ci/issues/304)'s admin-grant ask, no standalone action.
- **`ogc-modspec`** — semi-active (last push 2025-09-27); future maintenance will be in-house rather than external (@cnreediii), keeping it as cimas-domain. Stays in `cimas.yml`.

🤖
