### PR TITLE
fix: derive gem name from upstream gemspec in dependent-rake

### DIFF
--- a/.github/workflows/dependent-rake.yml
+++ b/.github/workflows/dependent-rake.yml
@@ -123,7 +123,23 @@ jobs:
         import subprocess
         import sys
         import os
+        import re
         gem_name = '${{ github.event.repository.name }}'
+        # The GitHub repo name does not always match the gem name declared
+        # in the gemspec (e.g. the unitsdb-ruby repo ships the "unitsdb"
+        # gem; unitsml-ruby ships "unitsml"). Read the gem name from the
+        # upstream gemspec at the workspace root so `bundle add` resolves
+        # to the right gem. Falls back to the repo name when no gemspec
+        # is present.
+        upstream_gemspecs = glob.glob('../*.gemspec')
+        if upstream_gemspecs:
+          with open(upstream_gemspecs[0]) as gemspec_file:
+            for line in gemspec_file:
+              match = re.match(r'\s*spec\.name\s*=\s*["\']([^"\']+)["\']', line)
+              if match:
+                gem_name = match.group(1)
+                break
+          print("Detected gem name from {}: {}".format(upstream_gemspecs[0], gem_name))
         if glob.glob('*.gemspec'):
           gemspec = glob.glob('*.gemspec')[0]
           with fileinput.FileInput(gemspec, inplace=True) as file:


### PR DESCRIPTION
## Summary

- Derives `gem_name` in the `dependent-rake` reusable workflow from `spec.name` in the upstream gemspec, instead of using `${{ github.event.repository.name }}`.

## Why

The workflow currently sets `gem_name` to the GitHub **repo** name. For repos where the gem name differs from the repo name, the downstream step `bundle add <gem_name> --path ..` fails with:

```
Could not find gem 'unitsdb-ruby' in source at `..`.
```

because the gemspec at `..` declares `spec.name = "unitsdb"`. This has been failing on every push to affected repos for months. Concrete examples:

| Repo | gemspec name | `bundle add` (current) | `bundle add` (after fix) |
| --- | --- | --- | --- |
| `unitsml/unitsdb-ruby` | `unitsdb` | `bundle add unitsdb-ruby --path ..` (fails) | `bundle add unitsdb --path ..` |
| `unitsml/unitsml-ruby` | `unitsml` | `bundle add unitsml-ruby --path ..` (fails) | `bundle add unitsml --path ..` |

The fix reads `spec.name` from `../*.gemspec` at the start of the step. For repos where the repo name already equals the gem name (the common case), behavior is unchanged. The fallback remains the repo name, so repos without a root-level gemspec are unaffected.

## Test plan

- [x] Regex validated against 9 cases (single/double quotes, trailing comments, no-space `=`, commented-out lines, non-`spec.name` lines).
- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Re-run `depenedent-gems.yml` on `unitsml/unitsdb-ruby` and `unitsml/unitsml-ruby` and confirm the previously-failing `bundle add ... --path ..` step now succeeds.
