### PR TITLE
Add minimal permissions: contents: read to 5 sample-template workflows

### DIFF
--- a/cimas-config/gh-actions/samples/docker.yml
+++ b/cimas-config/gh-actions/samples/docker.yml
@@ -12,6 +12,9 @@ on:
     types: [ metanorma/metanorma-docker ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-docker:
     uses: metanorma/ci/.github/workflows/sample-docker.yml@main

--- a/cimas-config/gh-actions/samples/generate.yml
+++ b/cimas-config/gh-actions/samples/generate.yml
@@ -10,6 +10,9 @@ on:
       - .github/workflows/docker.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-docker:
     uses: metanorma/ci/.github/workflows/sample-gen.yml@main

--- a/cimas-config/gh-actions/samples/public-generate.yml
+++ b/cimas-config/gh-actions/samples/public-generate.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   site-generate:
     name: Generate on ${{ matrix.os }}

--- a/cimas-config/gh-actions/samples/test.yml
+++ b/cimas-config/gh-actions/samples/test.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [ metanorma/metanorma-* ]
 
+permissions:
+  contents: read
+
 jobs:
   test-docker:
     uses: metanorma/ci/.github/workflows/sample-test.yml@main

--- a/cimas-config/gh-actions/samples/user-docker.yml
+++ b/cimas-config/gh-actions/samples/user-docker.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-docker:
     uses: metanorma/ci/.github/workflows/user-docker.yml@main


### PR DESCRIPTION
Refs https://github.com/metanorma/X.icd-schemas/security/code-scanning/2
Refs https://github.com/metanorma/ci/issues/302

## Summary

Adds `permissions: contents: read` (GitHub's recommended minimal baseline) to the 5 sample-template workflows that were missing an explicit `permissions:` block. Closes the `actions/missing-workflow-permissions` (medium-severity) code-scanning alerts those templates produce wherever they're synced.

Surfaced by [`metanorma/X.icd-schemas`'s code-scanning alert #2](https://github.com/metanorma/X.icd-schemas/security/code-scanning/2) (medium-severity, on the `generate.yml` that the 2026-06-24 cimas sync wave added there). Widened audit found the same gap in 5 of 6 sample templates — the alert is the visible tip of a broader template-hygiene issue, not a one-off.

## Audit

| Template | `permissions:` before | This PR |
|---|---|---|
| `gh-actions/samples/docker.yml` | ❌ missing | ✅ adds `contents: read` |
| `gh-actions/samples/generate.yml` | ❌ missing | ✅ adds `contents: read` |
| `gh-actions/samples/public-docker.yml` | ✅ present (no change) | — |
| `gh-actions/samples/public-generate.yml` | ❌ missing | ✅ adds `contents: read` |
| `gh-actions/samples/test.yml` | ❌ missing | ✅ adds `contents: read` |
| `gh-actions/samples/user-docker.yml` | ❌ missing | ✅ adds `contents: read` |

## Why `contents: read` specifically

GitHub's code-scanning rule message recommends `{contents: read}` as the minimal starting point. For the templates here:

- **`public-generate.yml`** is self-contained (does its own checkout + build, uploads an artifact, no writes back). `contents: read` is exactly right.
- **`docker.yml`, `generate.yml`, `test.yml`, `user-docker.yml`** are thin callers of reusable workflows in `metanorma/ci/.github/workflows/`. Two of those reusables (`sample-docker.yml`, `user-docker.yml`) declare their **own** `permissions:` block with the write scopes they need (`pages: write`, `id-token: write`, etc.); per GitHub Actions semantics, a reusable workflow's own permissions block overrides what the caller declared, so adding `contents: read` to the thin caller doesn't constrain those reusables. The remaining two (`sample-gen.yml`, `sample-test.yml`) have no own permissions block and inherit the caller's — `contents: read` is sufficient for what they do (build + test, no writes back to the repo).

If any specific reusable workflow ever turns out to need broader scope than its caller grants, the failure surfaces with a clear GitHub Actions permissions error and the caller's block can be widened then. Better to fail visibly under a restricted scope than to leave the medium-severity scanning alerts open.

## Propagation

Lands in the master templates; the ~17 metanorma-org repos that take these templates (and any future cimas-sync consumers) pick up the `permissions:` block on the next cimas sync wave. Existing downstream files on `main` continue to ride the older template until then — no migration ceremony required.

## Out of scope

- Sibling alert [`X.icd-schemas` code-scanning alert #1](https://github.com/metanorma/X.icd-schemas/security/code-scanning/1) (same rule, on `build.yml`) is on the repo's own `main`, not from a cimas template. That's a separate fix for the repo owner.
- `.erb` template files in `gh-actions/samples/` (`private-docker.yml.erb`, `private-fonts.yml.erb`) — not in scope of this PR. They'd be a separate audit.

🤖
