### PR TITLE
fix: refresh bundle after version bump in rubygems-release

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -115,6 +115,15 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
         run: gem bump --version ${{ inputs.next_version }} --tag --push
 
+      # Regenerate Gemfile.lock after the version bump so Bundler has an
+      # up-to-date lockfile and materialized git sources. Without this,
+      # `bundle exec rake release` fails with "git source ... is not yet
+      # checked out" because Bundler cannot re-resolve from a missing lock
+      # in the middle of the publish step.
+      - name: Refresh bundle after bump
+        if: inputs.bundler_cache
+        run: bundle install --quiet
+
       # ============ Gem identity ============
       # Resolved AFTER the bump so name/version/gemspec reflect the just-bumped
       # version. If resolved before the bump, the idempotency guard, build, and


### PR DESCRIPTION
## Summary

Adds a `bundle install --quiet` step between the version bump and gem-identity resolution in `rubygems-release.yml`.

## Why

`rm -f Gemfile.lock` + `gem bump --tag --push` leaves the workspace without a lockfile. The subsequent `bundle exec rake release` (default `release_command`) then fails for any repo whose Gemfile pulls a gem from a `github:` source:

```
bundler: failed to load command: rake (...)
The git source https://github.com/<org>/<repo>.git is not yet
checked out. Please run `bundle install` before trying to start
your application (Bundler::GitError)
```

Concrete failures today:
- `unitsml/unitsdb-ruby` do-release run 28315801946 (lutaml-model git source)
- `unitsml/unitsml-ruby` workflow_dispatch run 28315683006 (lutaml-model + plurimath git sources)

In both cases the `workflow_dispatch` run completes "successfully" (it just bumps + tags) but the `repository_dispatch(do-release)` publish step fails, so the gem never reaches RubyGems.

## Fix

Add `bundle install --quiet` after the bump so the lockfile is regenerated and all git sources are materialized before `bundle exec rake release` runs. Gated on `inputs.bundler_cache` because consumers that disable bundler-driven install must already handle materialization themselves.

## Test plan

- [x] Diff reads cleanly; only adds a new step, no existing behavior changed for `bundler_cache: false` consumers.
- [ ] Re-run a `do-release` on `unitsml/unitsdb-ruby` and `unitsml/unitsml-ruby` after merge; confirm the gem publishes.