### PR TITLE
Add public husk gems for metanorma-nist (1.5.0) and metanorma-bsi (0.7.0)

### DIFF
--- a/husks/.gitignore
+++ b/husks/.gitignore
@@ -1,0 +1,2 @@
+*.gem
+.DS_Store

--- a/husks/README.md
+++ b/husks/README.md
@@ -1,0 +1,46 @@
+# Public husk gems
+
+This directory holds the source of record for **public RubyGems husk gems** maintained by the metanorma org. Husks are deprecation-stub gems published to public RubyGems so that the resolver picks them over older 2019-era public versions of gems whose active development has since moved private. They have no runtime dependencies and no functional code — just a deprecation `warn` on load pointing at the private GitHub Packages source.
+
+## Why these exist
+
+Around 2019, several metanorma flavour repos were privatised at the request of their sponsoring standards bodies. Active development moved to private GitHub Packages publishing. But the existing public RubyGems entries for those gems were left in place at their last 2019/2020/2021-era version, with 2019/2020/2021-era dependency pins. Anyone running `gem install metanorma-<flavour>` from public — without scoping to the private GH Packages source — gets that ancient version, which drags the entire downstream metanorma stack backwards by years.
+
+The husk strategy fixes this by publishing a NEW public version that is:
+
+- **Above** the current public husk version (so the resolver picks it for fresh `gem install`)
+- **In a version gap** the private team won't use (so we don't shadow any real private release)
+- **Below** the active private major (so anyone pinning to the active major continues to get the private gem via GH Packages, untouched)
+
+The husk loads with a clear deprecation warning explaining the private-source migration path.
+
+## Current husks
+
+| Gem | Husk version | Replaces public | Tracking issue |
+|---|---|---|---|
+| `metanorma-nist` | `1.5.0` | `1.3.2` (2021-05-25, 2021-era pins) | [`metanorma/metanorma-nist#497`](https://github.com/metanorma/metanorma-nist/issues/497) |
+| `metanorma-bsi` | `0.7.0` | `0.0.1` (2021-04-25, never-functional placeholder) | [`metanorma/metanorma-bsi#625`](https://github.com/metanorma/metanorma-bsi/issues/625) |
+
+Both were surfaced via triage of [`metanorma/metanorma#568`](https://github.com/metanorma/metanorma/issues/568) (Peter Wyatt, PDF Association), even though that ticket's actual bug was unrelated env-orphan gems on the reporter's side.
+
+## Build + push
+
+From each husk directory:
+
+```sh
+cd husks/metanorma-nist
+gem build metanorma-nist.gemspec
+gem push metanorma-nist-1.5.0.gem
+```
+
+Requires a RubyGems API key with publish rights on the `metanorma-nist` (resp. `metanorma-bsi`) gem name, in `~/.gem/credentials`.
+
+## When to add a husk here
+
+Only when a metanorma-org gem has:
+
+1. An existing public RubyGems version with stale 2019-2021-era dependency pins, AND
+2. Active development that has moved to a private GitHub Packages source, AND
+3. A real risk of external consumers being dragged backwards by `gem install <name>` from public.
+
+Audit of all 20 metanorma flavour repos (2026-06-28) confirmed `metanorma-nist` and `metanorma-bsi` are currently the only two fitting this pattern. Other stale public versions exist (gb, vg, m3d, mpfa, m3aawg) but those repos are archived and not on the release path, so they are not husk candidates.

--- a/husks/metanorma-bsi/README.md
+++ b/husks/metanorma-bsi/README.md
@@ -1,0 +1,15 @@
+# metanorma-bsi (public husk)
+
+Deprecation stub for `metanorma-bsi` on public RubyGems. Active development has moved to private GitHub Packages at the request of BSI.
+
+See [`husks/README.md`](../README.md) for the broader pattern, and [`metanorma/metanorma-bsi#625`](https://github.com/metanorma/metanorma-bsi/issues/625) for the tracking issue.
+
+If you have authorised access to the private GitHub Packages registry, configure your `Gemfile`:
+
+```ruby
+source "https://rubygems.pkg.github.com/metanorma" do
+  gem "metanorma-bsi"
+end
+```
+
+See <https://github.com/metanorma/metanorma-bsi> for access and migration information.

--- a/husks/metanorma-bsi/lib/metanorma-bsi.rb
+++ b/husks/metanorma-bsi/lib/metanorma-bsi.rb
@@ -1,0 +1,1 @@
+require "metanorma/bsi"

--- a/husks/metanorma-bsi/lib/metanorma/bsi.rb
+++ b/husks/metanorma-bsi/lib/metanorma/bsi.rb
@@ -1,0 +1,11 @@
+module Metanorma
+  module Bsi
+    DEPRECATION_NOTICE = <<~NOTICE
+      [metanorma-bsi] This public gem is a deprecation stub.
+      Active development has moved to private GitHub Packages.
+      See https://github.com/metanorma/metanorma-bsi for access.
+    NOTICE
+
+    warn DEPRECATION_NOTICE
+  end
+end

--- a/husks/metanorma-bsi/metanorma-bsi.gemspec
+++ b/husks/metanorma-bsi/metanorma-bsi.gemspec
@@ -1,0 +1,31 @@
+Gem::Specification.new do |spec|
+  spec.name          = "metanorma-bsi"
+  spec.version       = "0.7.0"
+  spec.authors       = ["Ribose Inc."]
+  spec.email         = ["open.source@ribose.com"]
+
+  spec.summary       = "DEPRECATED PUBLIC STUB — metanorma-bsi development is private."
+  spec.description   = <<~DESC
+    This is a deprecation stub. Active metanorma-bsi development has moved
+    to a private GitHub Packages registry at the request of BSI.
+
+    If you have authorised access, configure your Gemfile to pull from the
+    private source:
+
+      source "https://rubygems.pkg.github.com/metanorma" do
+        gem "metanorma-bsi"
+      end
+
+    See https://github.com/metanorma/metanorma-bsi for access and migration
+    information.
+  DESC
+  spec.homepage      = "https://github.com/metanorma/metanorma-bsi"
+  spec.license       = "BSD-2-Clause"
+
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
+
+  spec.files         = Dir["lib/**/*", "README.md"]
+  spec.require_paths = ["lib"]
+
+  # NO runtime dependencies. That is the entire point of the husk.
+end

--- a/husks/metanorma-nist/README.md
+++ b/husks/metanorma-nist/README.md
@@ -1,0 +1,15 @@
+# metanorma-nist (public husk)
+
+Deprecation stub for `metanorma-nist` on public RubyGems. Active development has moved to private GitHub Packages at the request of NIST.
+
+See [`husks/README.md`](../README.md) for the broader pattern, and [`metanorma/metanorma-nist#497`](https://github.com/metanorma/metanorma-nist/issues/497) for the tracking issue.
+
+If you have authorised access to the private GitHub Packages registry, configure your `Gemfile`:
+
+```ruby
+source "https://rubygems.pkg.github.com/metanorma" do
+  gem "metanorma-nist"
+end
+```
+
+See <https://github.com/metanorma/metanorma-nist> for access and migration information.

--- a/husks/metanorma-nist/lib/metanorma-nist.rb
+++ b/husks/metanorma-nist/lib/metanorma-nist.rb
@@ -1,0 +1,1 @@
+require "metanorma/nist"

--- a/husks/metanorma-nist/lib/metanorma/nist.rb
+++ b/husks/metanorma-nist/lib/metanorma/nist.rb
@@ -1,0 +1,11 @@
+module Metanorma
+  module Nist
+    DEPRECATION_NOTICE = <<~NOTICE
+      [metanorma-nist] This public gem is a deprecation stub.
+      Active development has moved to private GitHub Packages.
+      See https://github.com/metanorma/metanorma-nist for access.
+    NOTICE
+
+    warn DEPRECATION_NOTICE
+  end
+end

--- a/husks/metanorma-nist/metanorma-nist.gemspec
+++ b/husks/metanorma-nist/metanorma-nist.gemspec
@@ -1,0 +1,31 @@
+Gem::Specification.new do |spec|
+  spec.name          = "metanorma-nist"
+  spec.version       = "1.5.0"
+  spec.authors       = ["Ribose Inc."]
+  spec.email         = ["open.source@ribose.com"]
+
+  spec.summary       = "DEPRECATED PUBLIC STUB — metanorma-nist development is private."
+  spec.description   = <<~DESC
+    This is a deprecation stub. Active metanorma-nist development has moved
+    to a private GitHub Packages registry at the request of NIST.
+
+    If you have authorised access, configure your Gemfile to pull from the
+    private source:
+
+      source "https://rubygems.pkg.github.com/metanorma" do
+        gem "metanorma-nist"
+      end
+
+    See https://github.com/metanorma/metanorma-nist for access and migration
+    information.
+  DESC
+  spec.homepage      = "https://github.com/metanorma/metanorma-nist"
+  spec.license       = "BSD-2-Clause"
+
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
+
+  spec.files         = Dir["lib/**/*", "README.md"]
+  spec.require_paths = ["lib"]
+
+  # NO runtime dependencies. That is the entire point of the husk.
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-nist/issues/497
Refs https://github.com/metanorma/metanorma-bsi/issues/625
Refs https://github.com/metanorma/metanorma/issues/568

## Summary

Adds a new `husks/` directory to `metanorma/ci` holding the source of record for public RubyGems husk gems. Initial contents: `metanorma-nist` (husk version `1.5.0`) and `metanorma-bsi` (husk version `0.7.0`).

## Why

Around 2019 the `metanorma-nist` and `metanorma-bsi` repos were privatised at the request of NIST and BSI. Active development moved to private GitHub Packages publishing — that part is intentional. The defect is that the existing public RubyGems entries for those gems were left in place:

- public `metanorma-nist` 1.3.2 (2021-05-25) declares `isodoc ~> 1.6.0`, `metanorma-standoc ~> 1.9.0` — 2021-era pins that drag any downstream consumer's metanorma stack back to 2021.
- public `metanorma-bsi` 0.0.1 (2021-04-25) is a never-functional placeholder that pins `metanorma-iso ~> 1.8.0`, `mn2sts ~> 1.5.0`.

Anyone running `gem install metanorma-nist` (or `metanorma-bsi`) from public — without explicitly scoping their `Gemfile` to the private GH Packages source — gets that ancient version silently. This was surfaced via triage of [`metanorma/metanorma#568`](https://github.com/metanorma/metanorma/issues/568) (Peter Wyatt, PDF Association) — that ticket's actual bug turned out to be unrelated env orphans on the reporter's side, but the triage uncovered this distinct stale-public-husk pattern as a real architectural hole.

Audit of all 20 metanorma flavour repos confirmed `metanorma-nist` and `metanorma-bsi` are currently the only two fitting this pattern.

## What the husks do

Each husk has:

- A gemspec with **zero runtime dependencies** and a clear deprecation `summary` + `description` pointing at the private GH Packages source.
- A minimal `lib/` namespace matching the original gem (so old `require "metanorma/nist"` calls fall through to a deprecation `warn` rather than raising `LoadError`).
- `required_ruby_version >= 3.3.0` aligning with the current stack floor.

The husk's only job is to break the dependency logjam: be the version the resolver picks for unconstrained public installs, so they get a clean "this is now private" warning instead of the silent 2021-era stack drag.

## Why these version numbers

| Gem | Husk version | Rationale |
|---|---|---|
| `metanorma-nist` | `1.5.0` | Above current public `1.3.2`; in the gap between private `1.4.5` and private `2.0.0`; below the active private major `2.x` (current private `2.8.7`). |
| `metanorma-bsi` | `0.7.0` | Above current public `0.0.1`; in the gap between private `0.6.3` and private `1.0.0`; below the active private major `1.x` (current private `1.6.9`). |

Consumers scoping to private GH Packages with `~> 2` (nist) or `~> 1` (bsi) continue to resolve against the private gem, untouched by the husks.

## Verification done

```sh
cd husks/metanorma-nist && gem build metanorma-nist.gemspec
# Successfully built RubyGem
#   Name: metanorma-nist
#   Version: 1.5.0
#   File: metanorma-nist-1.5.0.gem (5120 bytes)

cd ../metanorma-bsi && gem build metanorma-bsi.gemspec
# Successfully built RubyGem
#   Name: metanorma-bsi
#   Version: 0.7.0
#   File: metanorma-bsi-0.7.0.gem (5120 bytes)
```

Built `.gem` files are not committed (per `husks/.gitignore`); the source-of-record is what lives in the repo.

## What this does NOT do

- **Does not yank** existing public `1.3.2` / `0.0.1`. Yanks are irreversible per RubyGems rules.
- **Does not affect private GH Packages consumers** — their scoped Gemfile shape continues to resolve via GH Packages unchanged.
- **Does not affect any other flavour gem** — audit confirmed nist + bsi are the only two in this pattern. Other stale public versions exist (gb, vg, m3d, mpfa, m3aawg) but those repos are archived and not on the release path.

## Next steps after merge

1. `gem push` of both husks to public RubyGems (manual; uses existing `metanorma` rubygems API key).
2. Close [`metanorma-nist#497`](https://github.com/metanorma/metanorma-nist/issues/497) and [`metanorma-bsi#625`](https://github.com/metanorma/metanorma-bsi/issues/625) with the published rubygems URLs.
3. Append the closure record to the cimas-revival SSOT at `metanorma/cimas:plans/cimas-revival-and-release-workflow-realignment.md`.

🤖
