### PR TITLE
rubygems-release: add preflight job to fail fast on bundle-resolve + gemspec + credentials

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -60,7 +60,102 @@ on:
         required: false
 
 jobs:
+  # Fail-fast preflight: run a fresh `bundle install` BEFORE bump/tag/rake so
+  # any dep-resolution issue (e.g. a GH Packages auth slip, an unsatisfiable
+  # version constraint, a missing private gem) surfaces in ~90 seconds rather
+  # than after the 2h+ rake matrix. Skipped on `repository_dispatch`/`push`
+  # events because those code paths already passed preflight in the preceding
+  # `workflow_dispatch` leg; running it again would just duplicate work.
+  # See release-chain.md and metanorma/ci#309 for the maintainer-experience
+  # rationale (the v1.16.6 case that motivated this: 2h27m wasted to learn
+  # bundle install failed at layer 7).
+  preflight:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      HAVE_PAT_TOKEN: ${{ secrets.pat_token != '' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+          submodules: ${{ inputs.submodules }}
+          token: ${{ secrets.pat_token || github.token }}
+
+      - if: ${{ env.HAVE_PAT_TOKEN == 'true' }}
+        uses: metanorma/ci/gh-rubygems-setup-action@main
+        with:
+          token: ${{ secrets.pat_token }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: false
+
+      - name: Fresh bundle resolve (catches what would otherwise fail at layer 7)
+        run: |
+          rm -f Gemfile.lock
+          bundle install --jobs 4 --retry 3
+
+      - name: Gem build (catches gemspec errors that would fail at layer 9)
+        run: |
+          gemspec=$(ls *.gemspec | head -1)
+          if [ -z "$gemspec" ]; then
+            echo "::error::No .gemspec file found in repo root"
+            exit 1
+          fi
+          echo "Building $gemspec to verify gemspec validity..."
+          gem build "$gemspec"
+          rm -f *.gem  # don't carry the artefact forward
+
+      - name: Verify publish credentials available
+        env:
+          HAS_API_KEY: ${{ secrets.rubygems-api-key != '' }}
+          ROLE_TO_ASSUME: ${{ inputs.role_to_assume }}
+        run: |
+          if [ "$HAS_API_KEY" = "true" ]; then
+            echo "✓ rubygems-api-key configured; publish will use API-key path"
+          elif [ -n "$ROLE_TO_ASSUME" ]; then
+            echo "✓ OIDC role configured (role_to_assume input set); publish will use Trusted Publishing path"
+          else
+            echo "::error::Neither rubygems-api-key secret nor role_to_assume input is configured."
+            echo "::error::The publish step at layer 9 will fail. Configure one of:"
+            echo "::error::  - rubygems-api-key secret on the calling repo, OR"
+            echo "::error::  - role_to_assume input in the caller workflow (for OIDC Trusted Publishing)."
+            exit 1
+          fi
+
+      - name: Version awareness (informational)
+        run: |
+          gemspec=$(ls *.gemspec | head -1)
+          gem_name=$(ruby -e "puts Gem::Specification.load('$gemspec').name")
+          gem_version=$(ruby -e "puts Gem::Specification.load('$gemspec').version.to_s")
+          published=$(gem list --remote --exact --version "$gem_version" "$gem_name" 2>/dev/null | grep "$gem_name ($gem_version)" || true)
+          if [ -n "$published" ]; then
+            if [ "${{ inputs.next_version }}" = "skip" ]; then
+              echo "::warning::$gem_name $gem_version is already on rubygems.org."
+              echo "::warning::With next_version=skip, the idempotent guard at layer 8 will SKIP the push."
+              echo "::warning::If you intended to re-trigger the chain on an existing version (e.g. to retry a failed downstream cascade), this is fine."
+              echo "::warning::If you intended to ship NEW code, cancel this run and fire with next_version=patch (or major/minor) instead."
+            else
+              echo "ℹ️  Current gemspec version $gem_name $gem_version is already published. After bump ($(echo '${{ inputs.next_version }}')), the new version will be higher."
+            fi
+          else
+            echo "ℹ️  $gem_name $gem_version is not on rubygems yet."
+            latest=$(gem list --remote --exact "$gem_name" 2>/dev/null | grep -oE "$gem_name \([0-9.]+\)" | head -1 || echo "(not previously published)")
+            echo "ℹ️  Latest published: $latest"
+          fi
+
   release:
+    # Run after preflight when preflight ran (workflow_dispatch path); run
+    # directly when preflight was skipped (repository_dispatch / push paths).
+    # Do NOT run if preflight ran and failed — that means a real dep issue
+    # the maintainer needs to fix before any further chain layers execute.
+    needs: preflight
+    if: |
+      always() &&
+      (needs.preflight.result == 'success' || needs.preflight.result == 'skipped')
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:

--- a/release-chain.md
+++ b/release-chain.md
@@ -33,6 +33,29 @@ The "gated-direct" release model (adopted 2026-06-18, see [`metanorma/cimas:plan
 
 Total wall-clock for a happy-path release: 30 min – 2.5 h, dominated by the rake matrix.
 
+## Preflight (fail-fast guard, runs before layer 1)
+
+A `preflight` job in `rubygems-release.yml` runs as the very first job on every `workflow_dispatch` invocation (skipped on `repository_dispatch` and `push` paths because those already passed preflight in the originating `workflow_dispatch` leg). It runs the cheap, deterministic checks that would otherwise fail much later in the chain. **Total cost: ~90 sec – 2 min**. If it fails, the chain stops immediately — no bump, no tag, no rake. The `release` job is gated by `needs: preflight` with `if: success() || skipped`.
+
+What preflight verifies:
+
+| Check | Catches | Would otherwise fail at |
+|---|---|---|
+| **Fresh `bundle install` resolve** (with `Gemfile.lock` removed first) | Dep resolution failures: GH Packages auth slip, unsatisfiable version constraint, missing private gem — the v1.16.6 case. | Layer 7, **~2h27m in** |
+| **`gem build <gemspec>`** | Gemspec errors: syntax, missing files declared in `spec.files`, invalid `required_ruby_version`, bad metadata | Layer 9, **~2h+ in** |
+| **Verify publish credentials available** | Neither `rubygems-api-key` secret nor `role_to_assume` input configured → no publish path viable | Layer 9, ~2h+ in |
+| **Version awareness** (informational, not blocking) | Flags when current gemspec version is already published — for `next_version=skip` this means the chain will re-trigger but the publish itself will idempotent-skip. Helps maintainer recognise re-publish-of-existing-version scenarios before committing to the 2h rake wait. | (would just silently no-op at layer 8) |
+
+Preflight is **not** a substitute for the full chain — it's a gate that filters out the cheap-to-detect failure modes early. Things preflight cannot catch (and which still surface later):
+
+- Actual test failures in the rake matrix (layers 2/3 — that's the point of the matrix)
+- MFA / OTP prompts at `gem push` (one-time codes can't be dry-run)
+- OIDC trust-policy mismatches (the token exchange happens at publish time)
+- Downstream cascade failures (layer 12 — a separate workflow on the per-gem side)
+- Failures only reproducible on a specific runner OS (preflight runs on ubuntu-latest)
+
+See [`metanorma/ci#309`](https://github.com/metanorma/ci/issues/309) for the maintainer-experience rationale that motivated preflight (the v1.16.6 case: 2h27m wasted to learn `bundle install` failed at layer 7).
+
 ## Layer-by-layer: what can fail, how to recognise, how to recover
 
 ### Layer 1 — `workflow_dispatch` on per-gem `release.yml`
@@ -109,7 +132,7 @@ Total wall-clock for a happy-path release: 30 min – 2.5 h, dominated by the ra
 
 **Recovery.** Local reproduction: run `bundle install` on a clean checkout of the gem with the same Ruby version (`ruby/setup-ruby@v1` uses Ruby 3.3 in this workflow). If it fails locally too, the issue is the Gemfile or the GH Packages publication; if it passes locally, it's the CI env (token scope, auth setup).
 
-**This is the target of the planned Track A fail-fast preflight job** (issue [#309](https://github.com/metanorma/ci/issues/309) remediation slate): hoist this same `bundle install` to the *head* of the `workflow_dispatch` path, before bump/tag/rake, so it fails in 90 seconds instead of 2h 27m.
+**This is now caught by the preflight job** (see "Preflight" section above) — preflight runs a fresh `bundle install` (with `Gemfile.lock` removed) on every `workflow_dispatch` invocation, BEFORE bump/tag/rake. The v1.16.6-shape failure now surfaces in ~90 sec instead of 2h 27m. If you see the failure at layer 7 anyway (i.e. preflight passed but the live release run still failed here), the cause is likely environment drift between the preflight invocation and the do-release invocation — worth investigating as a real anomaly.
 
 ### Layer 8 — Idempotent `gem-push` guard
 
@@ -190,7 +213,7 @@ A failure at layer N often leaves the system in a state that's partially-release
 
 ## Known-fragile edges as of 2026-06-28
 
-- **Layer 7** (`bundle install`) is the most common failure point that wastes the most time (after layer 2/3 rake completes). Fail-fast preflight job to be added per #309 Track A.
+- **Layer 7** (`bundle install`) was the most common failure point that wasted the most time. **Now caught by the preflight job** (see "Preflight" above) — fails in ~90 sec instead of 2h 27m. The v1.16.6 case that motivated this would have surfaced before any bump or tag was pushed.
 - **Layer 12** (downstream cascade) was silent-broken for 5+ weeks before discovery — fixed structurally by [`metanorma-cli#427`](https://github.com/metanorma/metanorma-cli/pull/427) + [`#430`](https://github.com/metanorma/metanorma-cli/pull/430), but the observability gap that allowed it to hide is still open ([`#302`](https://github.com/metanorma/ci/issues/302)).
 - **Layer 9** OTP: rubygems MFA prompts for OTP. If the API key has MFA enforcement and there's no human at the terminal to paste the OTP, `gem push` fails. Workaround: use OIDC Trusted Publishing where possible; or rotate to an MFA-disabled key for CI use only.
 - **Public husk gems** (`metanorma-nist 1.5.0`, `metanorma-bsi 0.7.0`): shipped 2026-06-28 to close the privatisation-public-husk hole for external `gem install` consumers. Doesn't change anything for the release chain itself, but worth knowing the husks exist when reading bundler resolution logs.


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/309

## Summary

Adds a `preflight` job at the head of `rubygems-release.yml` that runs the cheap, deterministic failure-prone checks **before** bump/tag/rake, so the kind of failure that bit `metanorma-cli` v1.16.6 on 2026-06-27 (`Bundler::GemNotFound: metanorma-nist` at layer 7, surfaced after 2h 27m of rake matrix) now surfaces in ~90 seconds.

Updates `release-chain.md` in the same PR to document the preflight job and what it covers / cannot cover, plus updates the layer-7 and "Known-fragile edges" sections to reflect that the bundle-resolve failure mode is now caught early.

This is the **Track A** half of the [#309](https://github.com/metanorma/ci/issues/309) remediation slate (the *documentation* half landed in [#312](https://github.com/metanorma/ci/pull/312) earlier).

## What the preflight job does

Runs only on `workflow_dispatch` events (skipped on `repository_dispatch`/`push` paths since those already passed preflight in their originating `workflow_dispatch` leg). Four checks, total cost ~90 sec – 2 min:

| Check | Catches | Mode |
|---|---|---|
| **Fresh `bundle install` resolve** (`Gemfile.lock` removed first) | Dep resolution failures: GH Packages auth slip, unsatisfiable version constraint, missing private gem — the v1.16.6 case. | Hard fail |
| **`gem build <gemspec>`** | Gemspec errors: syntax, missing files in `spec.files`, invalid `required_ruby_version`, bad metadata | Hard fail |
| **Verify publish credentials present** | Neither `rubygems-api-key` secret nor `role_to_assume` input configured → no viable publish path | Hard fail |
| **Version awareness** | Flags when current gemspec version is already on rubygems — for `next_version=skip` this means the chain will re-trigger but the publish itself will idempotent-skip | Informational only (warns, doesn't block) |

The `release` job is gated by `needs: preflight` with `if: always() && (success || skipped)` so:
- On `workflow_dispatch`: preflight runs; if it fails, release is blocked; if it passes, release proceeds.
- On `repository_dispatch` or `push`: preflight is skipped; release proceeds normally.

## What the preflight does NOT catch

Spelled out in the docs update too — these are the failure modes that still surface later in the chain because they fundamentally can't be preflighted:

- Actual test failures in the rake matrix (that's the point of the matrix)
- MFA / OTP prompts at `gem push` (one-time codes can't be dry-run)
- OIDC trust-policy mismatches (token exchange happens at publish time)
- Downstream cascade failures at layer 12 (separate workflow on the per-gem side)
- Failures only reproducible on a specific runner OS (preflight runs on ubuntu-latest)

## Why preflight as a new job rather than reordering existing steps (D-minimal)

The `bundle install` already happens via `ruby/setup-ruby@v1` with `bundler-cache: true` inside the existing `release` job, but it runs there with the lockfile cache populated and with the same checked-out ref used for the publish step. Adding a separate preflight job means:

- We run a **fresh** resolve (lockfile removed) — closer to what the `repository_dispatch` re-invocation will see
- We isolate the cheap checks from the expensive publish/dispatch logic
- We add `gem build` + credentials-check + version-awareness checks that don't belong inside the publish job
- We get a clean job-level pass/fail signal (gates the release job via `needs:`)

D-minimal (reorder bundle install inside the release job to be earlier) would catch the same single failure mode at the same speed, but wouldn't accommodate the additional 3 checks. Track D-full (restructuring the 11 layers more deeply) is deferred per [#309](https://github.com/metanorma/ci/issues/309) discussion.

## Verification

YAML parse passes (`ruby -ryaml -e 'YAML.load_file(".github/workflows/rubygems-release.yml")'`). The preflight job's logic was modelled on the existing `release` job's setup steps (checkout + gh-rubygems-setup + ruby/setup-ruby), so its environment matches what the live release run would see.

End-to-end exercise will happen on the next gem release attempt — at which point we'll see the preflight job run first in the workflow_dispatch run, ~90 seconds total, before any bump or tag.

🤖
