### PR TITLE
rubygems-release: hardcode bundler-cache: false to stop stale-restore silent missing-gem

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -30,10 +30,18 @@ on:
         type: string
         default: bundle exec rake release
       bundler_cache:
-        description: 'do bundle install'
+        description: |
+          DEPRECATED — IGNORED as of 2026-06-28 (see metanorma/ci#314).
+          The release job now hardcodes bundler-cache: false because this
+          workflow removes Gemfile.lock before bump, which combined with
+          ruby/setup-ruby's restore-key fallback caused stale-cache restores
+          and silent missing-gem failures (e.g. metanorma-cli v1.16.6
+          failed with "Bundler::GemNotFound: metanorma-nist" because the
+          gem was never actually installed despite being in the Gemfile).
+          Cost of fresh install: ~30 sec per release.
         required: false
         type: boolean
-        default: true
+        default: false
       post_install:
         description: 'command to execute after bundle install'
         required: false
@@ -190,7 +198,12 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: ${{ inputs.bundler_cache }}
+          # bundler-cache hardcoded to false (ignoring inputs.bundler_cache)
+          # because this workflow removes Gemfile.lock before bump, which
+          # makes ruby/setup-ruby's restore-key fallback hit stale caches
+          # and silently skip installing newly-added gems. See
+          # metanorma/ci#314 for the root-cause analysis.
+          bundler-cache: false
 
       - if: ${{ inputs.post_install != '' }}
         run: ${{ inputs.post_install }}

--- a/release-chain.md
+++ b/release-chain.md
@@ -120,11 +120,11 @@ See [`metanorma/ci#309`](https://github.com/metanorma/ci/issues/309) for the mai
 **What it does.** `ruby/setup-ruby@v1` with `bundler-cache: true` resolves the gem's `Gemfile` against all configured sources (public rubygems.org + the scoped GH Packages source for `metanorma-nist` / `metanorma-bsi`). All transitive dependencies installed.
 
 **Failure modes.**
-- *`Bundler::GemNotFound`*: a specifically-scoped gem isn't resolvable. Could be:
+- *`Bundler::GemNotFound: Could not find gem 'X' in locally installed gems`*: **stale bundler-cache hit**. Root cause: `ruby/setup-ruby@v1`'s `bundler-cache: true` uses GitHub Actions cache keyed on `Gemfile.lock` hash. metanorma-org gems don't commit `Gemfile.lock`, so the cache key is unstable, and `ruby/setup-ruby` falls back to **partial-key restore-match** — restoring a cache from a previous release run that had a different Gemfile state. After the stale restore, `bundle install` only installs the diff (often a single recent gem), leaving any newly-added gems silently un-installed. The next `bundle exec rake release` then fails. **Bit the metanorma-cli v1.16.6 release twice** (2026-06-27 and 2026-06-28) on `metanorma-nist`. Fixed at source by [`metanorma/ci#314`](https://github.com/metanorma/ci/issues/314) (hardcode `bundler-cache: false` in the release job). Cost: ~30 sec extra per release for a fresh install.
+- *`Bundler::GemNotFound` (other)*: a specifically-scoped gem isn't resolvable at all (not stale cache). Could be:
   - GH Packages auth not propagated correctly (revisit layer 6)
   - The gem genuinely isn't published to GH Packages at the required version
   - Bundler resolution edge case with the scoped-source syntax
-  - **This is what bit the v1.16.6 release on 2026-06-27** (`Could not find gem 'metanorma-nist' in locally installed gems`). The 2026-06-28 husk fix changed the public-RubyGems side of this picture but doesn't address the GH Packages auth path the release flow takes.
 - *Version-constraint conflict*: one gem pins a version of another gem that contradicts a third. Recovery: relax constraints in the gemspec.
 - *Native extension build failure*: a transitively-pulled-in gem with a C extension fails to compile (e.g., `nokogumbo` on Ruby 4 — see the recent metanorma#568 env-orphan case as a non-release-side instance of the same shape). Recovery: pin to a version with prebuilt binaries or remove the dependency.
 
@@ -213,7 +213,7 @@ A failure at layer N often leaves the system in a state that's partially-release
 
 ## Known-fragile edges as of 2026-06-28
 
-- **Layer 7** (`bundle install`) was the most common failure point that wasted the most time. **Now caught by the preflight job** (see "Preflight" above) — fails in ~90 sec instead of 2h 27m. The v1.16.6 case that motivated this would have surfaced before any bump or tag was pushed.
+- **Layer 7** (`bundle install`) was the most common failure point that wasted the most time. **Two-layer fix now in place**: (1) preflight job catches resolution errors before bump/tag/rake (~90 sec instead of 2h 27m), and (2) [`#314`](https://github.com/metanorma/ci/issues/314) hardcodes `bundler-cache: false` to eliminate the stale-cache class of silent missing-gem failure that bit metanorma-cli v1.16.6 twice. Both fixes apply to every metanorma-org gem release.
 - **Layer 12** (downstream cascade) was silent-broken for 5+ weeks before discovery — fixed structurally by [`metanorma-cli#427`](https://github.com/metanorma/metanorma-cli/pull/427) + [`#430`](https://github.com/metanorma/metanorma-cli/pull/430), but the observability gap that allowed it to hide is still open ([`#302`](https://github.com/metanorma/ci/issues/302)).
 - **Layer 9** OTP: rubygems MFA prompts for OTP. If the API key has MFA enforcement and there's no human at the terminal to paste the OTP, `gem push` fails. Workaround: use OIDC Trusted Publishing where possible; or rotate to an MFA-disabled key for CI use only.
 - **Public husk gems** (`metanorma-nist 1.5.0`, `metanorma-bsi 0.7.0`): shipped 2026-06-28 to close the privatisation-public-husk hole for external `gem install` consumers. Doesn't change anything for the release chain itself, but worth knowing the husks exist when reading bundler resolution logs.


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/314
Refs https://github.com/metanorma/ci/issues/309

## Summary

Hardcodes `bundler-cache: false` on the release job's `ruby/setup-ruby@v1` step in `rubygems-release.yml`, and marks the `inputs.bundler_cache` parameter as DEPRECATED / ignored. Eliminates the silent-missing-gem class of release failures caused by stale bundler-cache restores.

## What was broken

`ruby/setup-ruby@v1` with `bundler-cache: true` uses GitHub Actions cache keyed on a `Gemfile.lock` hash. metanorma-org gems don't commit `Gemfile.lock`, so the cache key is unstable, and `ruby/setup-ruby` falls back to **partial-key restore-match** — restoring a cache from a previous run that may have had a different Gemfile state. After the stale restore, `bundle install` only installs the diff (often a single recent gem), leaving any newly-added gems silently un-installed. The next `bundle exec rake release` then fails with `Bundler::GemNotFound`.

This bit `metanorma-cli` v1.16.6 twice (2026-06-27 and 2026-06-28) on `metanorma-nist`:

```
Cache key:                ...Gemfile.lock-b31809f053... (current, computed)
Cache hit for restore-key: ...Gemfile.lock-ebde68ccbd... (older, different hash)
Cache restored successfully
Installing mn2pdf 2.60
Bundle complete! 16 Gemfile dependencies, 327 gems now installed.
...
bundler: failed to load command: rake
.../bundler/resolver.rb:354:in `raise_not_found!':
  Could not find gem 'metanorma-nist' in locally installed gems. (Bundler::GemNotFound)
```

The cache key and the restore-key hit have different hashes — confirming a stale restore. Only one gem was installed post-restore; `metanorma-nist` was assumed-cached but actually wasn't.

This isn't isolated to metanorma-cli — `rubygems-release.yml` is the central reusable workflow for **every** metanorma-org gem's release. Every gem in the fortnight release cycle is exposed to the same failure mode until this fix lands. See [`#314`](https://github.com/metanorma/ci/issues/314) for the full root-cause analysis.

## The fix

Two lines of YAML changed plus a comment-update:

```diff
       bundler_cache:
-        description: 'do bundle install'
+        description: |
+          DEPRECATED — IGNORED as of 2026-06-28 (see metanorma/ci#314).
+          [...full deprecation context...]
         required: false
         type: boolean
-        default: true
+        default: false
```

```diff
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: ${{ inputs.bundler_cache }}
+          # bundler-cache hardcoded to false because this workflow removes
+          # Gemfile.lock before bump, which makes ruby/setup-ruby's
+          # restore-key fallback hit stale caches. See metanorma/ci#314.
+          bundler-cache: false
```

The preflight job added in [`#313`](https://github.com/metanorma/ci/pull/313) already uses `bundler-cache: false` — that's why local `cimas release-preflight` passes when the live CI release run fails on the same gem set. This PR brings the release job to the same hygiene.

## What this costs

~30 seconds of additional `bundle install` time per release run (fresh resolve vs cache restore). Negligible against the 30-min – 2.5h total chain duration.

## What this does NOT do

- Doesn't change the input shape. `inputs.bundler_cache` still exists for backward compatibility with callers that pass it; the value is just ignored now. A future cleanup can remove the input entirely once we're confident no caller relies on it.
- Doesn't change the release.yml or any caller — callers passing `bundler_cache: true` will see a deprecation note in the input description and get `false` behaviour silently. No functional break for any existing caller.
- Doesn't fix the broader "11-layer chain is unmaintainable" concern in [`#309`](https://github.com/metanorma/ci/issues/309). That's separate; this is one specific failure mode within it.

## Documentation

`release-chain.md` updated in the same PR:
- Layer 7 failure-mode section now distinguishes "stale bundler-cache" (most common, this fix) from other `Bundler::GemNotFound` shapes.
- "Known-fragile edges" section updated to note both the preflight (catches resolve-time errors fast) AND this fix (eliminates the stale-cache class) are in place.

## Verification

YAML parse passes (`ruby -ryaml -e 'YAML.load_file(...)'`). End-to-end test will be a re-attempt of `metanorma-cli` v1.16.6 immediately after merge — fire `do-release` on the v1.16.6 tag and watch the release.yml run succeed past `bundle install` through to `gem push` → GH Release page → release-passed dispatch → docker rebuild.

🤖
