### PR TITLE
rubygems-release: add explicit bundle install (regression from #315)

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -218,6 +218,15 @@ jobs:
       - name: Remove Gemfile.lock before bump
         run: rm -f Gemfile.lock
 
+      # ============ Fresh bundle install ============
+      # ruby/setup-ruby above is invoked with bundler-cache: false (see
+      # metanorma/ci#314), so it does not run `bundle install` itself. We
+      # need an explicit fresh install before `bundle exec rake release`
+      # or it dies with Bundler::GemNotFound for anything in the Gemfile.
+      # Mirrors the preflight job's fresh-resolve step (same flags).
+      - name: Fresh bundle install
+        run: bundle install --jobs 4 --retry 3
+
       # ============ Version bump (workflow_dispatch only) ============
       - name: Bump version
         if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/314
Refs https://github.com/metanorma/ci/pull/315

## Summary

Adds the missing explicit `bundle install` step that #315 forgot. #315 hardcoded `bundler-cache: false` on the release job's `ruby/setup-ruby@v1`, but did not add a separate `bundle install` step to replace what `bundler-cache: true` was doing implicitly — so the release job ended up with **no gem-install step at all**, and `bundle exec rake release` died in 6 seconds with the same `Bundler::GemNotFound: metanorma-nist` error #315 was supposed to fix.

This PR fixes the regression by inserting an explicit `Fresh bundle install` step (mirroring the preflight job's identical step) between `Remove Gemfile.lock before bump` and `Bump version`.

## Evidence

`metanorma-cli` v1.16.6 re-attempt run [28324799517](https://github.com/metanorma/metanorma-cli/actions/runs/28324799517) (after #315 merged):

```
Step  5: Run ruby/setup-ruby@v1                  success  14:06:54 → 14:06:54   (0s — no install)
Step  9: Remove Gemfile.lock before bump         success  14:06:57 → 14:06:57
Step 15: Publish to rubygems.org (API Key)       FAILURE  14:06:57 → 14:06:57
         bundler: failed to load command: rake
         Bundler::GemNotFound: metanorma-nist
```

`ruby/setup-ruby@v1` with `bundler-cache: false` skips its own `bundle install` — that's the documented behaviour. The workflow had been relying on `bundler-cache: true` to do the install implicitly. When #315 turned that off, nothing was put in its place. The preflight job (#313) has an explicit `bundle install --jobs 4 --retry 3` step because it always runs with cache off; the release job needs the same step.

## The fix

```diff
       - name: Remove Gemfile.lock before bump
         run: rm -f Gemfile.lock

+      # ============ Fresh bundle install ============
+      # ruby/setup-ruby above is invoked with bundler-cache: false (see
+      # metanorma/ci#314), so it does not run `bundle install` itself. We
+      # need an explicit fresh install before `bundle exec rake release`
+      # or it dies with Bundler::GemNotFound for anything in the Gemfile.
+      # Mirrors the preflight job's fresh-resolve step (same flags).
+      - name: Fresh bundle install
+        run: bundle install --jobs 4 --retry 3
+
       # ============ Version bump (workflow_dispatch only) ============
       - name: Bump version
```

Position rationale: between Gemfile.lock-removal and bump, so `bundle install` resolves cleanly against the current (un-bumped) gemspec, and `gem bump` runs after deps are installed. Bump itself only edits the gemspec version string — it doesn't change dep state — so install-before-bump is safe.

## Verification

- YAML parses (`ruby -ryaml -e 'YAML.load_file(...)'`).
- End-to-end test will be a third re-attempt of `metanorma-cli` v1.16.6 immediately after merge.

## Why this slipped past #315

I conflated "ruby/setup-ruby does `bundle install` internally when `bundler-cache: true`" with "the workflow has an explicit `bundle install` step somewhere." It didn't. The cache flag was the only install mechanism in the release job. Should have caught this by step-tracing the release job before merging #315, or by reading the preflight job (#313) closely enough to notice it has a separate `bundle install` step for a reason.

🤖
