### PR TITLE
fontist actions: fix wrong description + document distinction (closes #237)

### DIFF
--- a/fontist-repo-setup/action.yml
+++ b/fontist-repo-setup/action.yml
@@ -1,5 +1,5 @@
 name: 'fontist-repo-action'
-description: 'composite action to setup private Fontist repos (Fontist must already be installed)'
+description: 'Configure the private metanorma Fontist repo (private-fonts-pat required). Assumes Ruby and Fontist are already installed by the caller. For the "from scratch" variant that also installs Ruby and Fontist, see fontist-setup.'
 inputs:
   private-fonts-pat:
     description: 'Setup private formulas with PAT'

--- a/fontist-setup/action.yml
+++ b/fontist-setup/action.yml
@@ -1,5 +1,5 @@
 name: 'fontist-setup-action'
-description: 'composite action which setup metanorma private GitHub packages for rubygems'
+description: 'Install Ruby (if missing) + install Fontist (if missing) + configure the private metanorma Fontist repo if a PAT is provided. All-in-one shape for callers that do not already have Ruby/Fontist set up. See fontist-repo-setup for the "Fontist already installed" minimal variant.'
 inputs:
   force-install:
     description: 'Force install if already installed'


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/237

## Summary

Per Option B of the investigation comment on `#237`: keep both `fontist-setup` and `fontist-repo-setup` (they are complementary, not redundant — one is "from scratch", the other is "Fontist already installed"), fix the wrong description on `fontist-setup`, and document the distinction between the two so future maintainers don't pick the wrong variant.

The fontist toolchain is fragile enough that a deletion + migration (Option A) would risk breaking `metanorma-cli/.github/workflows/fonts-check.yml` for no real gain. Conservative call.

## Changes

Two single-line `description:` edits, no behaviour change:

1. **`fontist-setup/action.yml`** — current description (`"composite action which setup metanorma private GitHub packages for rubygems"`) was a copy-paste error from `gh-rubygems-setup-action` and unrelated to what the action actually does. Replaced with an accurate description that names the all-in-one shape and points at the variant.

2. **`fontist-repo-setup/action.yml`** — augmented the description to point back at `fontist-setup` for the "from scratch" case.

## What this does NOT do

- No deletion of either action.
- No migration of `metanorma-cli/.github/workflows/fonts-check.yml`. The one remaining caller continues to use `fontist-setup` as before.
- No change to inputs, behaviour, or outputs of either action.

## Verification

`git diff` shows two single-line description changes. No YAML structural change.

🤖
