### PR TITLE
cimas-config: remove coradoc rake.yml sync mapping (refs #300 Gap 3)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -532,7 +532,10 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
+      # rake.yml removed: coradoc opted out of the shared rake template in
+      # commit d91d06d ("fix(ci): replace metanorma reusable workflow with
+      # direct rake job"). See metanorma/ci#300 (Gap 3) for the broader
+      # opt-out-detection design question.
       .github/workflows/release.yml: gh-actions/master/release.yml
   atmospheric:
     remote: ssh://git@github.com/metanorma/atmospheric


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Removes `.github/workflows/rake.yml: gh-actions/master/rake.yml` from coradoc's `cimas.yml` entry so future cimas-sync waves do not overwrite coradoc's opt-out.

## Why

Per the Gap 3 example in [`#300`](https://github.com/metanorma/ci/issues/300): `metanorma/coradoc/.github/workflows/rake.yml` was replaced in [`d91d06d`](https://github.com/metanorma/coradoc/commit/d91d06d) (*"fix(ci): replace metanorma reusable workflow with direct rake job"*) with a direct in-file matrix-test job that does not use `metanorma/ci/.github/workflows/generic-rake.yml@main`. As long as the entry remains in `cimas.yml`, every `cimas sync` run attempts to re-overwrite that file with the shared template, clobbering coradoc's deliberate opt-out.

Confirmed coradoc's `main` still carries the direct in-file matrix (no `uses: metanorma/ci/...` shape), so the opt-out is current and intentional. Reflecting that in cimas-config is mechanical hygiene.

## What this does

Single-line removal in `cimas-config/cimas.yml` (plus an explanatory comment block referencing the originating commit and the broader Gap-3 design question on `#300`). No other config touched.

## What this does NOT do

- Doesn't address Gap 3 generally — cimas still has no automated opt-out detection. The broader design (drift-audit subcommand that surfaces opt-out candidates and refuses to sync without override) remains open under `#300`.
- Doesn't change coradoc's `.rubocop.yml` or `release.yml` sync mappings — those stay cimas-managed.
- Doesn't change any other repo's cimas.yml entry. Other opt-outs may exist but need their own diagnosis.

🤖
