### PR TITLE
cimas-config: drop deprecated standalone pubid-* + pubid umbrella

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -532,7 +532,10 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
+      # rake.yml removed: coradoc opted out of the shared rake template in
+      # commit d91d06d ("fix(ci): replace metanorma reusable workflow with
+      # direct rake job"). See metanorma/ci#300 (Gap 3) for the broader
+      # opt-out-detection design question.
       .github/workflows/release.yml: gh-actions/master/release.yml
   atmospheric:
     remote: ssh://git@github.com/metanorma/atmospheric

--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -194,93 +194,19 @@ repositories:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
-  # pubid
-  pubid:
-    remote: ssh://git@github.com/metanorma/pubid
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-core:
-    remote: ssh://git@github.com/metanorma/pubid-core
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-ieee:
-    remote: ssh://git@github.com/metanorma/pubid-ieee
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-iso:
-    remote: ssh://git@github.com/metanorma/pubid-iso
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-iec:
-    remote: ssh://git@github.com/metanorma/pubid-iec
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-bsi:
-    remote: ssh://git@github.com/metanorma/pubid-bsi
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-cen:
-    remote: ssh://git@github.com/metanorma/pubid-cen
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-jis:
-    remote: ssh://git@github.com/metanorma/pubid-jis
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-itu:
-    remote: ssh://git@github.com/metanorma/pubid-itu
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-ccsds:
-    remote: ssh://git@github.com/metanorma/pubid-ccsds
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # pubid family — DEPRECATED in favour of the metanorma/pubid monorepo
+  # (see metanorma/ci#274 close-out 2026-06-29 and metanorma/ci#300 Gap 3).
+  # Removed on 2026-06-29 to stop cimas-sync from targeting deprecated repos:
+  #   - pubid (the old standalone umbrella entry that mapped master template
+  #     files onto the now-monorepo repo; can return once #300 Gap 2's
+  #     monorepo sub-template family lands)
+  #   - pubid-core, pubid-ieee, pubid-iso, pubid-iec, pubid-bsi, pubid-cen,
+  #     pubid-jis, pubid-itu, pubid-ccsds, pubid-nist, pubid-plateau (all
+  #     standalone repos last released 0.7.x in 2024-08; their gems on
+  #     rubygems are now published from metanorma/pubid:gems/ at 1.15.x)
+  # pubid-etsi remains below pending a separate audit of its deprecation status.
   pubid-etsi:
     remote: ssh://git@github.com/metanorma/pubid-etsi
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-nist:
-    remote: ssh://git@github.com/metanorma/pubid-nist
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  pubid-plateau:
-    remote: ssh://git@github.com/metanorma/pubid-plateau
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
@@ -1374,19 +1300,9 @@ groups:
   - metanorma-ieee
   - metanorma-jis
   - metanorma-plateau
-  pubid:
-  - pubid
-  - pubid-core
-  - pubid-ieee
-  - pubid-iso
-  - pubid-iec
-  - pubid-bsi
-  - pubid-cen
-  - pubid-jis
-  - pubid-itu
-  - pubid-ccsds
-  - pubid-nist
-  - pubid-plateau
+  # pubid group removed 2026-06-29 — all members (pubid umbrella + 11 standalone)
+  # are deprecated in favour of metanorma/pubid monorepo. See cimas.yml comment
+  # at the pubid-etsi entry above and metanorma/ci#274 close-out / #300 Gap 3.
   metanorma:
   - metanorma
   - metanorma-cli


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/274
Refs https://github.com/metanorma/ci/issues/300

## Summary

Removes the 12 deprecated `pubid*` entries from `cimas-config/cimas.yml` (the `pubid` umbrella + 11 standalone `pubid-*` repos) and the `pubid` group definition. Stops future `cimas-sync` waves from targeting deprecated repos.

## Why

During tonight's [`#274`](https://github.com/metanorma/ci/issues/274) pubid-narrow-wave, the 11 PRs opened against the standalone `metanorma/pubid-*` repos surfaced CI failures (`dependent-gems-test` — downstream consumers like `relaton-iso` cannot resolve the live `pubid-iso 1.15.x` against the repos' frozen `0.7.x` lineage). Triage:

- `metanorma/pubid` monorepo (active, latest commit 2026-06-26) contains all relevant gems under `gems/pubid-*/` and is publishing `pubid-iso 1.15.20` (released 2026-06-26) to rubygems.
- Standalone `metanorma/pubid-iso` last release tag: `v0.7.7` (2024-08-14, 22+ months old). Last merged PR: `#278` (2025-04-22, 14+ months old).
- The `dependent-gems-test` workflow on standalone `pubid-iso` `main` has been failing since at least 2026-06-16; no one is maintaining the standalone repos.

The 11 PRs from tonight's wave were closed with the deprecation explanation linking the monorepo. This PR is the cimas-side cleanup so the next wave doesn't recreate the same situation.

## Changes

- **Removed** 12 entries from `repositories:`: `pubid` (umbrella), `pubid-core`, `pubid-ieee`, `pubid-iso`, `pubid-iec`, `pubid-bsi`, `pubid-cen`, `pubid-jis`, `pubid-itu`, `pubid-ccsds`, `pubid-nist`, `pubid-plateau`.
- **Removed** the `pubid` group definition under `groups:`.
- **Kept** `pubid-etsi` (the only `pubid-*` standalone repo with recent activity at 2026-06-25; status pending separate audit — may or may not be deprecated too, leaving in place until confirmed).
- **Replaced** both removed sections with explanatory comments naming the originating tickets so future maintainers see the context.

## What this does NOT do

- Doesn't archive the standalone `pubid-*` repos on GitHub — that's a separate maintainer-level decision.
- Doesn't add `metanorma/pubid` (the monorepo) to the cimas-config — the master template's `uses: metanorma/ci/.github/workflows/generic-rake.yml@main` doesn't fit the monorepo's `monorepo: true, gem_directory: gems` shape. Re-adding requires [`#300`](https://github.com/metanorma/ci/issues/300) Gap 2 (monorepo sub-template family) to land first.
- Doesn't address `pubid-etsi` — flagged for separate audit.

## Concrete `#300` Gap 3 instance

This cleanup is a Gap-3-of-`#300` instance materialising in production: cimas didn't detect the deprecation, the wave targeted dead repos, and the recovery required hand-cleanup. The proposed drift-audit subcommand (documented in `metanorma/cimas:README.adoc` "Proposed extension — drift-audit / opt-out detection") would have caught this before the PRs opened.

🤖
