### PR TITLE
cimas-config: remove deprecated iso690render (legacy of relaton-render)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -431,13 +431,11 @@ repositories:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
-  iso690render:
-    remote: ssh://git@github.com/metanorma/iso690render
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # iso690render — DEPRECATED 2026-06-29: this repo hosts a legacy `relaton-render`
+  # gemspec; the active relaton-render gem is now published from
+  # https://github.com/relaton/relaton-render (different org). The metanorma/iso690render
+  # repo could not be archived from this account (admin perms required); removed
+  # from cimas-config so future cimas-sync waves don't target it.
   csa-ccm-tools:
     remote: ssh://git@github.com/metanorma/csa-ccm-tools
     branch: master
@@ -1286,7 +1284,7 @@ groups:
   - mn2pdf-ruby
   - mn2sts-ruby
   - stepmod2mn
-  - iso690render
+  # iso690render removed 2026-06-29 — legacy of relaton-render (now in relaton/ org)
   - csa-ccm-tools
   - reverse_adoc
   - tex2mn


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Removes `iso690render` from `cimas-config/cimas.yml` (repository entry + tools group membership). The `metanorma/iso690render` repo hosts a legacy `relaton-render.gemspec`; the active `relaton-render` gem (v1.3.0, latest 2026-06-15) is now published from [`relaton/relaton-render`](https://github.com/relaton/relaton-render) in a different org.

Per the `#274` pubid-style deprecation pattern (`#300` Gap 3): cimas had been silently planning to overwrite the legacy repo's config every sync. Removing the cimas-config entry stops that.

## Note

The `metanorma/iso690render` repo could not be archived from this account — `gh repo archive` returned a permission error. Archiving requires admin access on the repo; left for a maintainer with the right perms.

🤖