### PR TITLE
cimas-config: add missing metanorma-plugin-{datastruct,plantuml}

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -1216,6 +1216,20 @@ repositories:
       # .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
+  metanorma-plugin-datastruct:
+    remote: ssh://git@github.com/metanorma/metanorma-plugin-datastruct
+    branch: main
+    files:
+      .rubocop.yml: gh-actions/master/.rubocop.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
+      .github/workflows/release.yml: gh-actions/master/release.yml
+  metanorma-plugin-plantuml:
+    remote: ssh://git@github.com/metanorma/metanorma-plugin-plantuml
+    branch: main
+    files:
+      .rubocop.yml: gh-actions/master/.rubocop.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml
+      .github/workflows/release.yml: gh-actions/master/release.yml
   stepmod-utils:
     remote: ssh://git@github.com/metanorma/stepmod-utils
     branch: main
@@ -1488,7 +1502,9 @@ groups:
   - winget-metanorma
   plugins:
   - metanorma-plugin-lutaml
+  - metanorma-plugin-glossarist
   - metanorma-plugin-datastruct
+  - metanorma-plugin-plantuml
   ignore: # obsolete
   # infrastructure
   - ci


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Brings the full `metanorma-plugin-*` family under cimas-managed CI. Inventory triage on 2026-06-29 surfaced that:

- `metanorma-plugin-datastruct` was listed in the `plugins` group but had **no `repositories:` entry**, so `cimas sync` logged "\`not configured, skipping\`" for it on every wave. Adds the missing entry.
- `metanorma-plugin-plantuml` was absent from both `repositories:` and the `plugins` group. Adds both.
- `metanorma-plugin-glossarist` was in `repositories:` but missing from the `plugins` group. Adds to group.

After this PR, all four active metanorma-plugin-* repos (lutaml, glossarist, datastruct, plantuml) are fully covered in both `repositories:` and the `plugins` group. The new repos get the standard `.rubocop.yml` + `rake.yml` + `release.yml` mapping pattern.

## Activity context

Both newly-added repos are actively published Ruby gems (rubygems 0.3.11 and 1.0.15 respectively, last pushes within 3 weeks). Not the pubid-style deprecation pattern.

🤖