### PR TITLE
cimas-config patches: match both 'spec.' and 's.' gemspec block-var conventions

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -1604,6 +1604,12 @@ patches:
   ruby_version:
     files:
       - "*.gemspec"
-    find: 'spec\.required_ruby_version\s*=.*'
-    replace: 'spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")'
-    groups: [processor, pubid, model, tools, metanorma, plugins]
+    # Match both the common `Gem::Specification.new do |spec|` (`spec.` block-var)
+    # and the older `Gem::Specification.new do |s|` (`s.` block-var) conventions.
+    # The (spec|s) capture is preserved in the replacement via \1, so a gemspec
+    # using `s.` stays `s.` after substitution. Without the alternation, `s.`-style
+    # gemspecs (e.g. reverse_adoc.gemspec) silently skip the wave. Cf metanorma/cimas#49.
+    find: '(spec|s)\.required_ruby_version\s*=.*'
+    replace: '\1.required_ruby_version = Gem::Requirement.new(">= 3.3.0")'
+    # `pubid` group removed 2026-06-29 (deprecated standalone family — see line ~197).
+    groups: [processor, model, tools, metanorma, plugins]


### PR DESCRIPTION
Refs https://github.com/metanorma/cimas/issues/49
Refs https://github.com/metanorma/ci/issues/274

## Summary

Two-part fix to the `patches: ruby_version` block in `cimas-config/cimas.yml`:

1. **Relax the regex** to match both `spec.required_ruby_version` and `s.required_ruby_version` gemspec conventions. The capture is preserved in the replacement via `\1` so a gemspec using `s.` stays `s.` after the substitution (no stylistic mismatch).
2. **Strip the stale `pubid` group reference** from the groups list. The `pubid` group itself was removed in [`#319`](https://github.com/metanorma/ci/pull/319) (deprecated standalone family) but the patches groups list still pointed at it.

## Concrete unblock

[`metanorma/reverse_adoc/reverse_adoc.gemspec`](https://github.com/metanorma/reverse_adoc/blob/main/reverse_adoc.gemspec) uses `Gem::Specification.new do |s|` — the single-char block variable — so its `s.required_ruby_version = ">= 2.7.0"` line silently skipped the 2026-06-29 cimas-sync wave. This PR unblocks it for the next sync.

## Tracked bug

[`metanorma/cimas#49`](https://github.com/metanorma/cimas/issues/49) Bug 2.

🤖
