### PR TITLE
rubygems-release: add post-publish rubygems-API verification step (refs #302)

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -321,6 +321,45 @@ jobs:
         name: Wait for release to propagate
         run: gem exec rubygems-await pkg/*.gem
 
+      # ============ Post-publish verification ============
+      # Verify the just-published gem version is actually queryable on
+      # rubygems.org. Without this check, a silent-fail in the publish
+      # step (the gem push reports success but the gem isn't on rubygems
+      # for whatever reason — auth scope, registry routing, partial CDN
+      # propagation timing out the upstream timeout, etc.) leaves the
+      # release reporting green while consumers can't `gem install` the
+      # new version. See metanorma/ci#302 ("green means published"
+      # observability) and metanorma/ci#314 (stale bundler-cache class).
+      #
+      # Polls the rubygems versions JSON every 5s up to 120s total. The
+      # OIDC path already does propagation waiting via `rubygems-await`
+      # above, so this poll typically returns instantly for it. The API
+      # Key path has no such waiter, so this is the first verification.
+      - name: Verify gem published on rubygems.org
+        if: env.SHOULD_PUBLISH == 'true' && env.skip_push != 'true'
+        env:
+          GEM_NAME: ${{ steps.gem-identity.outputs.name }}
+          GEM_VERSION: ${{ steps.gem-identity.outputs.version }}
+        run: |
+          echo "Polling rubygems.org for ${GEM_NAME} version ${GEM_VERSION}..."
+          for i in $(seq 1 24); do
+            status=$(curl -sf -o /dev/null -w "%{http_code}" \
+              "https://rubygems.org/api/v1/versions/${GEM_NAME}.json" || true)
+            if [[ "$status" == "200" ]]; then
+              if curl -s "https://rubygems.org/api/v1/versions/${GEM_NAME}.json" \
+                   | jq -e --arg v "$GEM_VERSION" '.[] | select(.number == $v) | .number' > /dev/null; then
+                echo "✓ ${GEM_NAME} ${GEM_VERSION} confirmed live on rubygems.org"
+                exit 0
+              fi
+            fi
+            echo "  attempt $i/24: not yet visible, sleeping 5s..."
+            sleep 5
+          done
+          echo "::error::${GEM_NAME} ${GEM_VERSION} was not visible on rubygems.org after 120s of polling."
+          echo "::error::Either the publish step failed silently (the class metanorma/ci#302 was filed to surface) or rubygems propagation is unusually slow."
+          echo "::error::Inspect the publish step's logs above for the actual outcome before re-running."
+          exit 1
+
       # ============ Post-release event ============
       - name: Get current gem ref
         id: gem-tag-ref


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/302
Refs https://github.com/metanorma/ci/issues/314

## Summary

Adds a `Verify gem published on rubygems.org` step to `rubygems-release.yml`, run after both the API-key and OIDC publish paths. Polls the rubygems versions JSON API every 5 seconds for up to 120 seconds. If the just-published version isn't visible by then, fails the workflow with a clear error message naming the originating tickets.

Concrete instance of the `#302` "green means published" invariant — closes the `#314`-class silent-fail mode where the publish step appears to succeed but the gem is not actually live on rubygems.

## Why

`#302` calls out the gap between "the publish step reports success" and "consumers can actually `gem install` the new version." There are several ways the gap manifests:

- The API-key publish path runs `bundle exec rake release`, which builds + pushes in one shell invocation. If the push itself partially succeeds (e.g. auth scope mismatch silently truncating the push, registry-routing oddity, partial CDN propagation timing out the upstream timeout), the step's exit code can still be 0 while the gem isn't live.
- The OIDC path has `gem exec rubygems-await pkg/*.gem` for propagation waiting, but that's tied to a local `.gem` file presence and is OIDC-path-only. The API-key path has no equivalent.
- Even when the gem is genuinely live, downstream consumers polling a CDN may see propagation lag of 10-60 seconds. Without a verification step, the `release-passed` dispatch fires before the gem is visible to consumers, which can break dependent CI runs.

The new step closes all three by polling the public rubygems versions JSON until the just-published version is visible, then proceeding. This matches the shape proposed in the 2026-06-29 comment on [`#302`](https://github.com/metanorma/ci/issues/302#issuecomment-4826409426) (the post-`gem push` rubygems-API verification step).

## What this PR does

Adds one step after the existing `Wait for release to propagate` (OIDC-only) step:

```yaml
- name: Verify gem published on rubygems.org
  if: env.SHOULD_PUBLISH == 'true' && env.skip_push != 'true'
  env:
    GEM_NAME:    ${{ steps.gem-identity.outputs.name }}
    GEM_VERSION: ${{ steps.gem-identity.outputs.version }}
  run: |
    echo "Polling rubygems.org for ${GEM_NAME} version ${GEM_VERSION}..."
    for i in $(seq 1 24); do
      status=$(curl -sf -o /dev/null -w "%{http_code}" \
        "https://rubygems.org/api/v1/versions/${GEM_NAME}.json" || true)
      if [[ "$status" == "200" ]]; then
        if curl -s "https://rubygems.org/api/v1/versions/${GEM_NAME}.json" \
             | jq -e --arg v "$GEM_VERSION" '.[] | select(.number == $v) | .number' > /dev/null; then
          echo "✓ ${GEM_NAME} ${GEM_VERSION} confirmed live on rubygems.org"
          exit 0
        fi
      fi
      echo "  attempt $i/24: not yet visible, sleeping 5s..."
      sleep 5
    done
    echo "::error::${GEM_NAME} ${GEM_VERSION} was not visible on rubygems.org after 120s of polling."
    echo "::error::Either the publish step failed silently (the class metanorma/ci#302 was filed to surface) or rubygems propagation is unusually slow."
    echo "::error::Inspect the publish step's logs above for the actual outcome before re-running."
    exit 1
```

Polling shape: 24 × 5s = 120s max. Uses `jq -e` to check that the just-pushed version number is in the versions array. The `-e` flag makes jq exit non-zero if the filter produces no output, so the shell short-circuits correctly.

## Coverage

The step gates on `env.SHOULD_PUBLISH == 'true' && env.skip_push != 'true'` — same as the publish steps themselves — so it fires whenever a publish was attempted. Both the API-key and OIDC paths flow through it.

The OIDC path has `rubygems-await` immediately above this new step. In that path the new poll typically returns at attempt 1 (rubygems-await already waited for propagation), so the new step is near-instant overhead. In the API-key path, the new step is the only verification.

## Note on the existing `rubygems-await` step

This PR keeps `rubygems-await` in place for the OIDC path — it's proven, it operates on the locally-built `.gem` file, and replacing it would expand the blast radius unnecessarily. The new step complements rather than replaces. A future PR could consolidate to a single verification mechanism if useful.

## What this does NOT do

- Doesn't change the publish steps themselves.
- Doesn't add post-`release-passed` dispatch verification — that's the **second** scope addition in the [2026-06-29 comment on `#302`](https://github.com/metanorma/ci/issues/302#issuecomment-4826409426) (post-dispatch acknowledgement poll) and is a separate, larger piece of work. Filed for follow-up.
- Doesn't address the broader "11-layer chain failure modes" picture from `#309` — that's structural documentation work.

## Verification

YAML loads cleanly (`ruby -ryaml -e "YAML.load_file(...)"`). The next gem release run through this workflow will exercise the new step in anger. The expected result is a single `✓ <gem> <version> confirmed live on rubygems.org` line in the release run's log.

🤖
