### PR TITLE
rubygems-release: add post-dispatch acknowledgement verification (refs #302)

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -365,6 +365,14 @@ jobs:
         id: gem-tag-ref
         run: echo "value=refs/tags/v${{ steps.gem-identity.outputs.version }}" >> "$GITHUB_OUTPUT"
 
+      # Record an ISO-8601 timestamp BEFORE dispatching. The post-dispatch
+      # verification step below uses this as the lower bound when polling for
+      # the corresponding repository_dispatch workflow run.
+      - name: Record dispatch timestamp
+        if: env.SHOULD_PUBLISH == 'true'
+        id: dispatch-ts
+        run: echo "iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch release-passed
         if: env.SHOULD_PUBLISH == 'true'
         uses: peter-evans/repository-dispatch@v3
@@ -373,3 +381,51 @@ jobs:
           repository: ${{ github.repository }}
           event-type: release-passed
           client-payload: '{"ref": "${{ steps.gem-tag-ref.outputs.value }}", "sha": "${{ github.sha }}", "type": "release-passed"}'
+
+      # ============ Post-dispatch acknowledgement verification ============
+      # Verify the release-passed dispatch was actually received and started
+      # a downstream workflow run. The Dispatch step above reports success
+      # when peter-evans/repository-dispatch returns 2xx from the GitHub
+      # repository-dispatch API — that confirms the request was ACCEPTED by
+      # GitHub, NOT that it was received and acted on by a downstream
+      # workflow. The HTTP 422 silent-fail mode (metanorma/metanorma-cli#426
+      # is the canonical instance: the receiver rejected the dispatch payload
+      # shape because of a missing inputs declaration) would still report
+      # green at the dispatch step, because the rejection happens in a
+      # separate workflow run on the receiving side that nobody monitors.
+      #
+      # This step polls the same repo's workflow runs for one created after
+      # the dispatch timestamp with event=repository_dispatch. Times out at
+      # 90s. See metanorma/ci#302 ("dispatch accepted vs dispatch acted on"
+      # observability gap) and metanorma/metanorma-cli#426 (the original
+      # silent docker-rebuild failure that ran for 6 weeks unnoticed).
+      - name: Verify release-passed dispatch acknowledged downstream
+        if: env.SHOULD_PUBLISH == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.pat_token || github.token }}
+          REPO: ${{ github.repository }}
+          SINCE: ${{ steps.dispatch-ts.outputs.iso }}
+        run: |
+          echo "Polling ${REPO} for a repository_dispatch workflow run created since ${SINCE}..."
+          for i in $(seq 1 18); do
+            # List recent repository_dispatch runs (created descending),
+            # then jq-filter for runs created at-or-after our dispatch
+            # timestamp. Pipe to jq directly so the --arg variable
+            # injection works (gh api's --jq accepts only a single
+            # expression, not jq's --arg flag).
+            found=$(gh api "repos/${REPO}/actions/runs?event=repository_dispatch&per_page=10" \
+              | jq -r --arg since "$SINCE" \
+                  '.workflow_runs[] | select(.created_at >= $since) | "\(.id) \(.name // "?") \(.status)/\(.conclusion // "?") created=\(.created_at)"' \
+              | head -1)
+            if [[ -n "$found" ]]; then
+              echo "✓ Downstream repository_dispatch run found:"
+              echo "  $found"
+              exit 0
+            fi
+            echo "  attempt $i/18: no matching run yet, sleeping 5s..."
+            sleep 5
+          done
+          echo "::error::No repository_dispatch workflow run was created within 90s of the release-passed dispatch."
+          echo "::error::Either no workflow listens for repository_dispatch types: [release-passed] in ${REPO}, or the dispatch was rejected silently (the class metanorma/metanorma-cli#426 was filed to surface)."
+          echo "::error::Inspect https://github.com/${REPO}/actions for repository_dispatch runs near the timestamp ${SINCE}."
+          exit 1


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/302
Refs https://github.com/metanorma/metanorma-cli/issues/426

## Summary

Adds a `Verify release-passed dispatch acknowledged downstream` step to `rubygems-release.yml`, run after the existing `Dispatch release-passed` step. Polls the same repo's GHA `workflow_runs` API every 5 seconds for up to 90 seconds, looking for a `repository_dispatch` workflow run created at or after the dispatch timestamp. Fails the workflow with a clear error if none appears in time.

Concrete instance of the `#302` "dispatch accepted vs dispatch acted on" observability gap — closes the `#426`-class silent-fail mode where the dispatch reports success but no downstream workflow actually fires.

## Why

[`#302`](https://github.com/metanorma/ci/issues/302) names two distinct things both implicitly called "the dispatch reported success":

1. **Dispatch ACCEPTED.** The GitHub repository-dispatch API returned 2xx to `peter-evans/repository-dispatch`. This means the request was accepted by GitHub's API surface.
2. **Dispatch ACTED ON.** A workflow on the receiving end actually started a run in response.

The existing `Dispatch release-passed` step gives us (1) but says nothing about (2). The `#426` failure shape is exactly this gap: the receiver rejects the dispatch payload (for `#426` specifically, the metanorma-docker `build-push.yml` had a bare `workflow_dispatch:` block with no `inputs:` declaration, so the API silently rejected the `--field version` payload with HTTP 422 — but that rejection happens in a SEPARATE workflow run that nobody monitors, and the `Dispatch` step is already long-since green by the time it fires).

`#426` ran for 6 weeks without being noticed because of exactly this gap.

## What this PR does

Two new steps:

1. **`Record dispatch timestamp`** — captures the current ISO-8601 UTC timestamp into a step output. Runs immediately before `Dispatch release-passed`. This is the lower bound for the post-dispatch verification poll below.

2. **`Verify release-passed dispatch acknowledged downstream`** — runs after `Dispatch release-passed`. Polls 18 × 5 seconds (90 seconds total) for a workflow run in this repo with `event=repository_dispatch` created at or after the recorded timestamp. On match, prints the run id + name + status and exits 0. On timeout, errors with explicit references to `#302` and `metanorma-cli#426`.

Polling shape:

```bash
for i in $(seq 1 18); do
  found=$(gh api "repos/${REPO}/actions/runs?event=repository_dispatch&per_page=10" \
    | jq -r --arg since "$SINCE" \
        '.workflow_runs[] | select(.created_at >= $since) | "\(.id) \(.name // "?") \(.status)/\(.conclusion // "?") created=\(.created_at)"' \
    | head -1)
  if [[ -n "$found" ]]; then echo "✓ ... $found"; exit 0; fi
  echo "  attempt $i/18: no matching run yet, sleeping 5s..."
  sleep 5
done
exit 1
```

The jq filter is piped to `jq` directly rather than passed via `gh api --jq` because `gh api`'s `--jq` flag accepts only a single expression (not jq's own `--arg` flag for variable injection). The pipe shape keeps shell escaping clean.

## Smoke-tested locally

The jq filter shape returns the expected per-line output against real `metanorma-cli` history:

```
$ SINCE="2026-06-28T00:00:00Z"
$ gh api "repos/metanorma/metanorma-cli/actions/runs?event=repository_dispatch&per_page=5" | jq -r --arg since "$SINCE" '...'
28325056721 notify completed/success created=2026-06-28T14:16:28Z
28325008101 release completed/success created=2026-06-28T14:14:41Z
28324799517 release completed/failure created=2026-06-28T14:06:44Z
28323771594 release completed/failure created=2026-06-28T13:28:10Z
```

So the step's exit-0 path will match on the first such run created after the dispatch timestamp.

## What this does NOT catch

- A dispatch that IS received but where the receiver workflow's first run failed at its own first step. The step succeeds (a run was created), but that run might then fail downstream. That's a separate concern; the receiver workflow's own monitoring catches that.
- Cross-repo dispatches. The poll only sees runs in the SAME repo. If the dispatch is to a different repo (which `Dispatch release-passed` here is not — `repository: ${{ github.repository }}` ensures same-repo), the poll would time out. The current `rubygems-release.yml` only does same-repo dispatches, so this is fine for the current usage.

## Coverage

`if: env.SHOULD_PUBLISH == 'true'` on both new steps mirrors the existing `Dispatch release-passed` step.

## Linked

- [`metanorma/ci#302`](https://github.com/metanorma/ci/issues/302) — refs (second of the three observability additions named in the 2026-06-29 follow-up comment)
- [`metanorma/metanorma-cli#426`](https://github.com/metanorma/metanorma-cli/issues/426) — refs (the originating silent-fail incident this step is designed to prevent recurrence of)
- Companion PR landed earlier: [`metanorma/ci#325`](https://github.com/metanorma/ci/pull/325) — post-publish rubygems-API verification (first of the three observability additions; catches the `#314`-class silent fail).

🤖
