### PR TITLE
rubygems-release: skip dev+test groups in bundle install (closes #258)

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -224,8 +224,19 @@ jobs:
       # need an explicit fresh install before `bundle exec rake release`
       # or it dies with Bundler::GemNotFound for anything in the Gemfile.
       # Mirrors the preflight job's fresh-resolve step (same flags).
-      - name: Fresh bundle install
-        run: bundle install --jobs 4 --retry 3
+      #
+      # The release job does NOT need development or test groups — the
+      # release path is `gem build` + `gem push`, not running tests. Excluding
+      # those groups eliminates a class of release-blocking resolution
+      # failures where a transitively-pulled dev dependency happens to be
+      # unresolvable mid-rollout (metanorma/ci#258 — the metanorma-taste
+      # incident where its dev dep metanorma-cli's transitive graph was in
+      # flux). Skipping development and test groups closes that gap without
+      # changing what's actually published.
+      - name: Fresh bundle install (production groups only)
+        run: |
+          bundle config set --local without 'development test'
+          bundle install --jobs 4 --retry 3
 
       # ============ Version bump (workflow_dispatch only) ============
       - name: Bump version


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/258

## Summary

The "Fresh bundle install" step in `rubygems-release.yml` (added in [`#316`](https://github.com/metanorma/ci/pull/316) to fix the `#314`-class stale-bundler-cache issue) now does:

```sh
bundle config set --local without 'development test'
bundle install --jobs 4 --retry 3
```

Excludes the `development` and `test` Bundler groups from the install. The release path runs `bundle exec rake release` which only needs runtime dependencies; dev and test groups are not exercised. Resolving them was creating a class of release-blocking failures where a transitively-pulled dev dependency happened to be unresolvable mid-rollout — the canonical instance being [`metanorma-taste`](https://github.com/metanorma/metanorma-taste/actions/runs/24343442119/job/71077913540) blocked because its dev dep `metanorma-cli`'s transitive graph was in flux at that moment.

## Why the author's preferred "bypass Bundler entirely" path wasn't taken

`#258`'s body proposed `gem build *.gemspec; gem push *.gem` as the primary fix. That would also work — `gem build` reads only the gemspec (runtime deps), `gem push` uploads — and it's what you'd reach for as the manual workaround. The cost: replacing `bundle exec rake release` with a hand-rolled push loses any rake-side preflight (Gemfile.lock regen, file inclusion sanity checks, etc.) that the release Rakefile may do per-gem.

The proposed alternative path — `bundle config set --local without development test` before `bundle install` — keeps `bundle exec rake release` intact and just narrows what gets installed. That's a strict subset of behaviour change: the install step still runs (so `Gemfile.lock`-relevant resolution still happens for runtime deps), but the dev/test resolution branch is taken off the critical path. Lower-risk minimal-diff fix.

## What changed

Two-line addition to the `Fresh bundle install (production groups only)` step:

```diff
-      - name: Fresh bundle install
-        run: bundle install --jobs 4 --retry 3
+      - name: Fresh bundle install (production groups only)
+        run: |
+          bundle config set --local without 'development test'
+          bundle install --jobs 4 --retry 3
```

Updated comment block to name `#258` alongside the existing `#314` reference, explaining the constraint that prompted the addition.

## Verification

YAML loads cleanly. The next gem release run through this workflow will exercise the new shape. Expected behaviour: dev-only gems are skipped, the install completes faster (no transitive dev resolution), and `bundle exec rake release` proceeds as before.

## Backward compatibility

`bundle config set --local without 'development test'` writes to `.bundle/config` in the workspace. Each release job runs on a fresh runner with a fresh checkout, so this is workspace-local and doesn't persist across runs. No state leak to other jobs.

Callers don't need to opt in or change anything; the behaviour is on by default for the release job.

## What this does NOT do

- Doesn't change the preflight job's `bundle install` ([`#313`](https://github.com/metanorma/ci/pull/313)). The preflight intentionally resolves everything to surface the broadest class of failures fast; it's not the path that publishes the gem.
- Doesn't change the publish steps themselves. The `bundle exec rake release` invocation is unchanged.
- Doesn't address the underlying flavour-gem gemspec under-specification class that [`#210`](https://github.com/metanorma/ci/issues/210)'s triage just surfaced. That's an upstream-per-gem hygiene matter, not a CI-side workflow change.

🤖
