### PR TITLE
cimas-config: strip atmospheric (transferred to atmospheris org 2026-04-23)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -473,13 +473,12 @@ repositories:
       # direct rake job"). See metanorma/ci#300 (Gap 3) for the broader
       # opt-out-detection design question.
       .github/workflows/release.yml: gh-actions/master/release.yml
-  atmospheric:
-    remote: ssh://git@github.com/metanorma/atmospheric
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # atmospheric: transferred out of metanorma org on 2026-04-23 (same day a new
+  # `atmospheris` org was created to receive it; gem renamed atmospheric →
+  # atmospheris). Now lives at https://github.com/atmospheris/atmospheris and is
+  # outside cimas-managed scope. Pre-transfer entry kept in git history for
+  # reference. The silent push-fail this entry was producing in cimas waves is
+  # the canonical case for #300 Gap 3 (drift-audit) — see the issue thread.
   modspec-ruby:
     remote: ssh://git@github.com/metanorma/modspec-ruby
     branch: main


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Removes the stale `atmospheric:` entry from `cimas-config/cimas.yml`. The repo was **transferred out of the metanorma org on 2026-04-23** — same day a brand-new `atmospheris` org was created to receive it. The gem was also renamed `atmospheric → atmospheris`, so the redirected `full_name` is now `atmospheris/atmospheris` ([see live repo](https://github.com/atmospheris/atmospheris) — public, active, last push 2026-04-23). The cimas.yml entry has been silently push-failing in every wave since.

## Why this is the right action

- The new home is **not** in any metanorma-aligned org (`atmospheris` is a single-repo org owning only itself, created specifically to receive this transfer on 2026-04-23T05:21:06Z; the repo's last push the same day means the transfer was the originating event).
- The cimas-config schema serves metanorma-org-aligned gems; tracking a now-external single-repo org is out of scope.
- The silent push-failure this entry produced in every cimas wave since the transfer is operational noise without diagnostic value (cimas reports "push failed" without surfacing WHY).
- Pre-transfer entry preserved in git history (`git log -p cimas-config/cimas.yml`) for future reference if the transfer is ever rolled back.

## The structural lesson — this is the canonical case for `#300` Gap 3 drift-audit

The strip is the immediate fix; the structural fix is the **drift-audit subcommand** proposed as Gap 3 of [`#300`](https://github.com/metanorma/ci/issues/300). The acceptance criterion that would catch this class:

> Drift-audit must verify each `cimas.yml` `remote:` URL resolves to a still-existing repo **in the listed org**, distinguishing four failure modes:
>
> 1. **Repo deleted** — `gh api repos/<org>/<name>` returns 404.
> 2. **Repo archived** — `.archived == true`.
> 3. **Repo transferred out of listed org** — `gh api repos/<org>/<name>` returns redirect with `.full_name != <org>/<name>` (the exact pattern this PR resolves manually).
> 4. **Default-branch renamed** — `cimas.yml` `branch:` value no longer matches `.default_branch`.
>
> Each failure mode surfaces as a sync-blocking error with the specific diagnostic, rather than the current "push failed" with no further detail.

A separate comment on `#300` enumerates these alongside the existing Gap 3 scope so the implementation has the acceptance criteria spelled out.

## Verification

- The atmospheric entry's `remote:` URL (`metanorma/atmospheric`) is the only cimas.yml reference to this repo; no other entry references it.
- The 6-line comment block left in place preserves the historical context for anyone diff-spotting the absence.
- YAML loads cleanly.

🤖
