### PR TITLE
cimas-config: restore standoc + isodoc gated-release sync (per-repo moved back June 2026)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -108,9 +108,16 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      # metanorma-standoc do immediate release without waiting for unit tests pass
-      # .github/workflows/rake.yml: gh-actions/inkscape/rake.yml
-      # .github/workflows/release.yml: gh-actions/master/release.yml
+      # Restored to gated-release sync. The 2024-08-06 commit 099925c opted
+      # standoc out of the rake/release templates with "do immediate release
+      # without waiting for unit tests pass" — but the per-repo release.yml
+      # has since been moved back to the gated rubygems-release.yml@main path
+      # (June 2026), so the cimas.yml opt-out is stale. Template note: the
+      # original was gh-actions/plantuml/rake.yml; plantuml/ was removed in
+      # 1c8696e — using inkscape/rake.yml as the closest substitute (same as
+      # isodoc). Swap if the wave PR shows substantive divergence vs live.
+      .github/workflows/rake.yml: gh-actions/inkscape/rake.yml
+      .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-iso:
     remote: ssh://git@github.com/metanorma/metanorma-iso
@@ -392,9 +399,13 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      # isodoc do immediate release without waiting for unit tests pass
-      # .github/workflows/rake.yml: gh-actions/inkscape/rake.yml
-      # .github/workflows/release.yml: gh-actions/master/release.yml
+      # Restored to gated-release sync. The 2024-08-06 commit 099925c opted
+      # isodoc out with "do immediate release without waiting for unit tests
+      # pass" — but the per-repo release.yml has since been moved back to the
+      # gated rubygems-release.yml@main path (June 2026), so the cimas.yml
+      # opt-out is stale.
+      .github/workflows/rake.yml: gh-actions/inkscape/rake.yml
+      .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/integration.yml: gh-actions/inkscape/rake-daily.yml
   html2doc:
     remote: ssh://git@github.com/metanorma/html2doc


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Restores `cimas-config/cimas.yml` sync entries for `metanorma-standoc` and `isodoc`'s `rake.yml` + `release.yml` to align with the **gated-release policy** that the per-repo workflow files were moved back to **this month** (June 2026).

The cimas.yml entries had been carrying commented-out template references with the rationale "do immediate release without waiting for unit tests pass" since [commit `099925c`](https://github.com/metanorma/ci/commit/099925c) on **2024-08-06**. That rationale **no longer holds** — both repos' live `release.yml` files now `uses: metanorma/ci/.github/workflows/rubygems-release.yml@main` (the gated path). The per-repo update landed without a matching cimas.yml update, leaving the cimas-managed sync silently skipping the now-gated files.

This PR closes that drift.

## What changed

`cimas-config/cimas.yml`:

- **`metanorma-standoc`**: uncomment `.github/workflows/rake.yml` and `.github/workflows/release.yml` entries; replace the stale "immediate release" rationale with a restoration-context comment. Note: the original mapping was `gh-actions/plantuml/rake.yml` but the `plantuml/` template directory was removed in [`1c8696e`](https://github.com/metanorma/ci/commit/1c8696e); substituting `gh-actions/inkscape/rake.yml` as the closest equivalent (matches isodoc).
- **`isodoc`**: uncomment the same two entries; replace the stale rationale comment with the restoration-context one. `gh-actions/inkscape/rake.yml` was the original mapping and still exists.

`release.yml` template for both: `gh-actions/master/release.yml` (the gated path — same template every metanorma-org gem on the gated rubygems-release.yml@main flow uses).

## Why this is the right action

1. **Live policy is gated**: both repos' release.yml on `origin/main` calls `metanorma/ci/.github/workflows/rubygems-release.yml@main`. cimas.yml saying "they're opted out" contradicts the live state.
2. **Silent drift was harmful**: the cimas opt-out meant per-repo files could drift away from the org standard with no detection; the next wave PR (the one this enables) makes the divergence visible and fixable.
3. **No live regression risk**: the master/release.yml template is exactly what both repos' release.yml already uses. The rake.yml template substitution is the only place this PR makes a meaningful change — and that goes through wave-PR review where divergence shows up as a normal diff.

## Drift class

This is a canonical instance of the silent-opt-out drift class proposed as Gap 3 acceptance criterion #2 in [this `#300` comment](https://github.com/metanorma/ci/issues/300#issuecomment-4844577163) (the URL will resolve once that companion comment lands). Both standoc and isodoc were stale-opted-out by the cimas.yml after the per-repo files were moved back to gated — exactly the failure mode Gap 3's silent-opt-out detection is designed to surface.

**Detection time: the per-repo gating move was June 2026; this PR is 2026-07-01.** That's the better-case bound — the structural fix (Gap 3) would have caught it at the next sync attempt rather than waiting for a manual audit.

## Verification

- `ruby -ryaml -e "YAML.load_file('cimas-config/cimas.yml')"` passes.
- `metanorma-standoc`'s live `release.yml` confirmed to use `rubygems-release.yml@main` (checked via `gh api repos/metanorma/metanorma-standoc/contents/.github/workflows/release.yml`).
- `isodoc`'s live `release.yml` confirmed to use the same path.

The next cimas-sync wave will propose changes to standoc + isodoc; the PR review will show whether the rake.yml template (`inkscape/rake.yml`) lands cleanly or needs swapping. Either way, the drift is now visible rather than silent.

🤖
