### PR TITLE
cimas-config: document glossarist .rubocop.yml opt-out rationale

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -1208,6 +1208,20 @@ repositories:
     remote: ssh://git@github.com/metanorma/metanorma-plugin-glossarist
     branch: main
     files:
+      # .rubocop.yml opt-out: repo's live .rubocop.yml carries grandfathered
+      # config the master template can't express — specifically:
+      #   - inherits from BOTH oss-guides AND a local .rubocop_todo.yml
+      #     (grandfathered violations kept in a separate file, mirrors the
+      #     metanorma-taste pattern from the 2026-06-19 wave)
+      #   - inherit_mode: merge: - Exclude (repo-specific Exclude patterns
+      #     must merge with, not replace, the oss-guides ones)
+      #   - plugins: rubocop-rspec, rubocop-performance, rubocop-rake
+      #   - TargetRubyVersion: 3.0 (repo hasn't been bumped past 3.0 yet)
+      # Verified 2026-07-02: live .rubocop.yml on origin/main confirmed to
+      # carry the above; master/.rubocop.yml template can't produce this shape.
+      # Legitimate documented opt-out per #300 Gap 3 criterion class (documented).
+      # Revisit if cimas patches mode (cimas#38) grows an insertion mechanism
+      # capable of expressing the local overrides parametrically.
       # .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Documents the `metanorma-plugin-glossarist` `.rubocop.yml` opt-out rationale, converting it from **unverified** (flagged in yesterday's [Gap 3 criterion #2 comment](https://github.com/metanorma/ci/issues/300#issuecomment-4844812873)) to **verified documented opt-out**.

## Verification

Compared `metanorma-plugin-glossarist`'s live `origin/main:.rubocop.yml` against `cimas-config/gh-actions/master/.rubocop.yml`. The live file carries structural additions the master template can't express:

- **Two-level `inherit_from`**: `oss-guides/ci/rubocop.yml` (shared) + `.rubocop_todo.yml` (grandfathered per-repo violations). Same pattern used by `metanorma-taste` and known deliberately not-yet-swept per the 2026-06-19 wave discussion.
- **`inherit_mode: merge: - Exclude`**: the repo's `Exclude` patterns must *merge with* the oss-guides ones rather than replace them (default behaviour). Not overrideable from the template side.
- **`plugins:` list** (`rubocop-rspec`, `rubocop-performance`, `rubocop-rake`): rubocop plugin ecosystem stuff the master template intentionally doesn't opine on.
- **`TargetRubyVersion: 3.0`**: the repo hasn't been bumped past Ruby 3.0 yet; master's `TargetRubyVersion: 3.4` would fail-close on this repo's grandfathered code.

The master template's `.rubocop.yml` is (correctly) minimal — just the shared `inherit_from` + placeholder. It can't produce glossarist's specific shape, so the opt-out is structurally warranted.

## What changed

`cimas-config/cimas.yml`: added a 12-line rationale block above the commented-out `.rubocop.yml` line explaining the four structural reasons and the verification note. No behavioural change — the opt-out was already in effect via the commented-out line; this PR adds the audit trail.

## Follow-up (out of scope)

If the cimas `patches` mode ([`cimas#38`](https://github.com/metanorma/cimas/pull/38)) grows an *insertion* mechanism (currently only supports find/replace, not append/prepend), the grandfathered-shape could be expressed parametrically — repo would sync the master template + patches inject the local plugin list, `.rubocop_todo.yml` inclusion, and `TargetRubyVersion` override. Not proposing that here; documented as a Phase B revisit trigger.

## Drift-audit criteria coverage

This is a **legitimate documented opt-out** — the target class Gap 3 explicitly does NOT flag (per the [criterion #2 comment](https://github.com/metanorma/ci/issues/300#issuecomment-4844812873)'s "Documented opt-outs (legitimate, do not flag)" section). The audit criterion for Gap 3 gains a small bonus check: **the rationale line must not be empty** — an entry with a commented-out file line and no rationale should be flagged as `[DRIFT-INFO] <repo>:<file>: opt-out has no inline rationale; consider adding one for auditability.` This PR resolves glossarist's instance of that sub-class.

🤖
