### PR TITLE
rubygems-release: add patch-release breaking-change heuristic guard (closes #278)

### DIFF
--- a/.github/scripts/release-breaking-check.rb
+++ b/.github/scripts/release-breaking-check.rb
@@ -1,0 +1,231 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# release-breaking-check.rb
+#
+# metanorma/ci#278 — patch-release breaking-change heuristic guard.
+#
+# Runs three heuristics comparing the previous release tag against HEAD;
+# short-circuits on the first hit. Only invoked from rubygems-release.yml
+# when `github.event_name == 'workflow_dispatch'` and
+# `inputs.next_version == 'patch'` and the per-run override is not set.
+#
+# Exit codes:
+#   0 — no breaking change detected, release proceeds
+#   1 — breaking change detected, release halted (writes to $GITHUB_STEP_SUMMARY)
+#   2 — script error (missing tag, no gemspec, etc.); release proceeds with
+#       a warning since the guard must not itself become a CI reliability
+#       problem.
+
+require "open3"
+require "prism"
+
+def sh(*cmd)
+  out, status = Open3.capture2(*cmd)
+  [out, status.success?]
+end
+
+def latest_release_tag
+  out, ok = sh("git", "describe", "--tags", "--abbrev=0",
+               "--match", "v[0-9]*", "HEAD^")
+  return nil unless ok
+
+  tag = out.strip
+  tag.empty? ? nil : tag
+end
+
+def gemspec_path
+  Dir.glob("*.gemspec").first
+end
+
+def gem_name
+  path = gemspec_path
+  return nil unless path
+
+  File.basename(path, ".gemspec")
+end
+
+# --- Heuristic (a) — file deletion in gem-shipped paths ---
+#
+# Compare git tree between prev tag and HEAD, filtering to paths a
+# well-formed gemspec would typically ship (lib/, exe/, bin/, sig/,
+# top-level .rb/README/LICENSE). This is a proxy for
+# `Gem::Specification#files` diff — evaluating a gemspec at a specific
+# ref is unreliable (many gemspecs `require "./lib/.../version"` which
+# breaks under git-show), so we work off the file tree. A file
+# present at the previous tag under one of the shipping paths and
+# absent at HEAD is a "surface deletion."
+def deleted_shipping_files(prev_tag)
+  out, ok = sh("git", "diff", "--name-status", "--diff-filter=D",
+               "#{prev_tag}..HEAD", "--",
+               "lib/", "exe/", "bin/", "sig/")
+  return [] unless ok
+
+  out.each_line.map { |line| line.split("\t", 2)[1].to_s.chomp }
+    .reject(&:empty?)
+end
+
+# --- Heuristic (d) — Prism AST symbol diff ---
+#
+# Extract top-level defined names (module/class/def) from each Ruby file
+# at prev tag AND HEAD. A name present at prev tag and absent at HEAD is
+# a "symbol deletion." Uses Prism (stdlib since Ruby 3.2). Only scans
+# lib/**/*.rb to avoid noise from tests/specs/fixtures.
+def collect_defined_names(source)
+  return [] if source.nil? || source.empty?
+
+  parsed = Prism.parse(source)
+  return [] if parsed.failure?
+
+  names = []
+  visit = lambda do |node, prefix|
+    case node
+    when Prism::ModuleNode, Prism::ClassNode
+      full = [prefix, node.constant_path.slice].compact.join("::")
+      names << full
+      node.body&.child_nodes&.each { |c| visit.call(c, full) }
+    when Prism::DefNode
+      receiver = node.receiver ? "#{node.receiver.slice}." : "#"
+      names << "#{prefix}#{receiver}#{node.name}"
+    when Prism::ConstantWriteNode, Prism::ConstantPathWriteNode
+      target = node.respond_to?(:target) ? node.target.slice : node.name.to_s
+      names << "#{prefix}::#{target}"
+    else
+      node.child_nodes&.each { |c| visit.call(c, prefix) if c }
+    end
+  end
+  parsed.value.statements.body.each { |n| visit.call(n, "") }
+  names.uniq
+end
+
+def files_at_ref(ref, glob)
+  out, ok = sh("git", "ls-tree", "-r", "--name-only", ref, "--", glob)
+  return [] unless ok
+
+  out.each_line.map(&:chomp).select { |f| f.end_with?(".rb") }
+end
+
+def source_at_ref(ref, path)
+  out, ok = sh("git", "show", "#{ref}:#{path}")
+  ok ? out : nil
+end
+
+def deleted_top_level_symbols(prev_tag)
+  prev_files = files_at_ref(prev_tag, "lib/")
+  head_files = files_at_ref("HEAD", "lib/")
+
+  prev_names = prev_files.flat_map do |f|
+    collect_defined_names(source_at_ref(prev_tag, f))
+  end.uniq
+
+  head_names = head_files.flat_map do |f|
+    collect_defined_names(source_at_ref("HEAD", f))
+  end.uniq
+
+  # Exclude names known to be private-by-convention (leading underscore).
+  removed = (prev_names - head_names).reject { |n| n.split("::").last.to_s.start_with?("_") }
+  removed.sort.first(20) # cap list length in the summary
+rescue StandardError => e
+  warn "Prism AST diff failed: #{e.class}: #{e.message}"
+  []
+end
+
+# --- Heuristic (e) — gem-compare against previously-published rubygems ---
+#
+# Uses gem-compare (installed at CI setup time). Advisory only —
+# unlike heuristics (a) and (d), a failure here does NOT halt release
+# (it's captured in the summary as informational). Rationale: this
+# depends on rubygems.org being reachable and the previously-published
+# gem being present in a form gem-compare can diff; a rubygems outage
+# should not itself block a legitimate release.
+def gem_compare_summary
+  name = gem_name
+  return "gem-compare skipped: no gemspec found in repo root" unless name
+
+  out, _ok = sh("gem", "compare", "--brief", name, "prev")
+  return "gem-compare returned no output for #{name}" if out.strip.empty?
+
+  # Trim to first 40 lines to keep the step summary readable.
+  lines = out.split("\n").first(40)
+  lines.join("\n")
+rescue StandardError => e
+  "gem-compare threw #{e.class}: #{e.message}"
+end
+
+# --- Summary emission ---
+
+def emit_summary(prev_tag, deleted_files, removed_symbols, gem_compare_notes)
+  summary_path = ENV["GITHUB_STEP_SUMMARY"]
+  return unless summary_path
+
+  File.open(summary_path, "a") do |io|
+    io.puts <<~MD
+      ## ❌ Release halted: breaking-change heuristics tripped on a `patch` release
+
+      Compared `#{prev_tag}` (prev tag) → HEAD.
+
+    MD
+
+    unless deleted_files.empty?
+      io.puts "### Files deleted from gem-shipping paths"
+      io.puts
+      deleted_files.each { |f| io.puts "- `#{f}`" }
+      io.puts
+    end
+
+    unless removed_symbols.empty?
+      io.puts "### Top-level symbols present at prev tag, absent at HEAD"
+      io.puts
+      removed_symbols.each { |s| io.puts "- `#{s}`" }
+      io.puts "_(list capped at 20)_" if removed_symbols.size == 20
+      io.puts
+    end
+
+    io.puts "### gem-compare output (advisory)"
+    io.puts
+    io.puts "```"
+    io.puts gem_compare_notes
+    io.puts "```"
+    io.puts
+
+    io.puts <<~MD
+      ### What to do
+
+      A `patch` release should not remove publicly-accessible files or top-level symbols. Two recommended paths:
+
+      1. **Rerun with `next_version: minor` (or `major`)** — appropriate when the deletion is genuine API surface removal.
+      2. **Bump locally and push the tag**: `bundle exec rake release` (or `gem bump --version patch --tag --push` from your workstation). The `push: tags: v*` trigger of this same workflow publishes without the guard, putting responsibility for the bump magnitude squarely on the developer.
+
+      **Override (use sparingly):** rerun this workflow with `acknowledge_breaking_in_patch: true`. This is recorded in the run inputs and visible in the audit trail. Use only for non-API reasons (e.g. removing an accidentally-shipped fixture).
+
+      Guard mechanism: [metanorma/ci#278](https://github.com/metanorma/ci/issues/278).
+    MD
+  end
+end
+
+# --- Main ---
+
+prev_tag = latest_release_tag
+if prev_tag.nil?
+  warn "release-breaking-check: no previous release tag found; " \
+       "cannot compute diff. Release proceeds."
+  exit 2
+end
+
+deleted_files = deleted_shipping_files(prev_tag)
+removed_symbols = deleted_files.any? ? [] : deleted_top_level_symbols(prev_tag)
+gem_compare_notes = gem_compare_summary
+
+tripped = !deleted_files.empty? || !removed_symbols.empty?
+
+if tripped
+  emit_summary(prev_tag, deleted_files, removed_symbols, gem_compare_notes)
+  warn "release-breaking-check: guard tripped; see step summary."
+  exit 1
+else
+  puts "release-breaking-check: no surface deletion detected between " \
+       "#{prev_tag} and HEAD. Release proceeds."
+  puts "gem-compare (advisory):"
+  puts gem_compare_notes
+  exit 0
+end

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -61,6 +61,16 @@ on:
         required: false
         type: string
         default: ''
+      acknowledge_breaking_in_patch:
+        description: |
+          Override the patch-release breaking-change heuristic guard for this run.
+          Set to true ONLY when the guard's trip is a known false-positive
+          (e.g. removing an accidentally-shipped fixture file, or a rename that
+          preserves API). The override is recorded in the run inputs and visible
+          in the audit trail. See metanorma/ci#278.
+        required: false
+        type: boolean
+        default: false
     secrets:
       rubygems-api-key:
         required: false
@@ -186,6 +196,11 @@ jobs:
           ref: ${{ github.event.client_payload.ref || github.ref }}
           submodules: ${{ inputs.submodules }}
           token: ${{ secrets.pat_token || github.token }}
+          # fetch-depth: 0 needed for the release-breaking-check.rb guard
+          # (metanorma/ci#278) to compare prev tag vs HEAD across history.
+          # Cheap on typical gem repos (<100 MB); if payload cost ever
+          # matters, the guard could switch to a shallow-fetch strategy.
+          fetch-depth: 0
 
       - if: github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
         run: git fetch --tags origin
@@ -214,6 +229,36 @@ jobs:
           git config user.email github-actions@github.com
 
       - run: gem install gem-release
+
+      # ============ Breaking-change heuristic guard (patch, workflow_dispatch) ============
+      # Halts a manual `patch` release when the diff between the prev tag and
+      # HEAD shows deleted shipping-path files or removed top-level constants/
+      # methods. Only fires on workflow_dispatch + next_version=patch. See
+      # metanorma/ci#278 for the design rationale (v0.9.42 lutaml incident).
+      # The gem-compare install is required only for the advisory heuristic (e).
+      - name: Install gem-compare (for the breaking-change guard's advisory diff)
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.next_version == 'patch' &&
+          inputs.acknowledge_breaking_in_patch != true
+        run: gem install gem-compare
+
+      - name: Fetch release-breaking-check.rb from metanorma/ci
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.next_version == 'patch' &&
+          inputs.acknowledge_breaking_in_patch != true
+        run: |
+          curl -fsSL -o /tmp/release-breaking-check.rb \
+            https://raw.githubusercontent.com/metanorma/ci/main/.github/scripts/release-breaking-check.rb
+          test -s /tmp/release-breaking-check.rb
+
+      - name: Breaking-change heuristic guard
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.next_version == 'patch' &&
+          inputs.acknowledge_breaking_in_patch != true
+        run: ruby /tmp/release-breaking-check.rb
 
       - name: Remove Gemfile.lock before bump
         run: rm -f Gemfile.lock


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/278

## Summary

Implements **Option 1** from the [ticket body](https://github.com/metanorma/ci/issues/278): the patch-release breaking-change heuristic guard is added inline to `rubygems-release.yml`, **default-on** with a per-run `acknowledge_breaking_in_patch` opt-out flag. Only fires on manual `workflow_dispatch` + `next_version: patch` releases; automatic `push: tags: v*` releases are unaffected.

## What ships

Three files changed:

1. `.github/scripts/release-breaking-check.rb` (**new**, ~215 lines) — the guard Ruby script implementing heuristics (a), (d), and (e) from the ticket body.
2. `.github/workflows/rubygems-release.yml`:
    - New workflow input `acknowledge_breaking_in_patch` (boolean, default false) — per-run opt-out.
    - `fetch-depth: 0` on the release-job checkout (needed for prev-tag vs HEAD diff).
    - Three new steps between `gem install gem-release` (existing) and `Remove Gemfile.lock` (existing): `gem install gem-compare`, `curl` the guard script from raw.githubusercontent.com, then `ruby /tmp/release-breaking-check.rb`. All three gated by the same condition (`workflow_dispatch` + `patch` + not-overridden).

Total added wall-clock: ~5-18 s per manual patch release (per the ticket's estimate).

## How the guard works

Three heuristics, short-circuiting on the first hit:

- **(a) Deleted shipping-path files** — `git diff --diff-filter=D <prev-tag>..HEAD -- lib/ exe/ bin/ sig/`. Proxy for `Gem::Specification#files` diff (evaluating a gemspec at a specific ref is unreliable because many gemspecs `require "./lib/…/version"` which breaks under `git show`). Cost: ~50 ms.
- **(d) Prism AST diff** — for each `lib/**/*.rb` at prev tag AND HEAD, extract top-level module/class/def names via Prism (Ruby stdlib since 3.2). A name present at prev tag and absent at HEAD is a symbol deletion. List capped at 20 in the summary to keep it readable. Cost: ~0.5-2 s.
- **(e) `gem-compare` against previously-published rubygems version** — advisory-only (rubygems outage should not itself block release). Output trimmed to first 40 lines in the summary. Cost: ~5-15 s.

Exit codes: `0` clean, `1` guard tripped, `2` script error (no prev tag, etc.) → release proceeds with a warning.

## Empirically validated on real cases

Tested against the `lutaml/lutaml` sibling clone. Four scenarios:

| From → To | Bump type | Guard result | What tripped it |
|---|---|---|---|
| v0.9.41 → v0.9.42 (**the ticket's incident**) | patch | ❌ tripped (exit 1) | `lib/lutaml/converter/xmi_hash_to_uml.rb` deletion |
| v0.10.9 → v0.10.10 | patch | ❌ tripped | 3 method removals (Prism heuristic) |
| v0.10.10 → v0.10.11 | patch | ✅ clean (exit 0) | — |
| v0.10.8 → v0.10.9 | patch | ✅ clean (exit 0) | — |
| v0.10.17 → v0.10.18 | patch | ❌ tripped | 4 file deletions (`lib/lutaml/qea/lookup_indexes.rb`, `lib/lutaml/xml.rb`, `lib/lutaml/xml/parsers/xml.rb`, `lib/lutaml/xml/parsers/xsd.rb`) |

Two positives (both real incident-shape, one known + one newly-surfaced) and two negatives (clean patches confirmed no false-fire). The v0.10.17→v0.10.18 result is a finding of its own — the class of incident the ticket describes has been recurring on this repo.

Full summary emitted to `$GITHUB_STEP_SUMMARY` when tripped includes the deleted files, removed symbols, gem-compare output, and actionable "what to do" (rerun as minor/major, bump locally, or override with the flag).

## Blast radius

- **Affected**: every consumer of `metanorma/ci/.github/workflows/rubygems-release.yml@main` on manual `workflow_dispatch` + `next_version: patch` invocations. This includes the metanorma-org gems directly, plus the `<org>/support` wrappers used by relaton, lutaml, plurimath, and fontist that thin-wrap this reusable.
- **Not affected**: automatic `push: tags: v*` releases (unchanged path); non-patch bumps (unchanged); consumers with a per-run override flag.
- **Reversibility**: single-file PR to revert.

Heads-up posts will follow on `relaton/support`, `lutaml/support`, `plurimath/support`, `fontist/support` issue queues naming the opt-out flag so those maintainers aren't blindsided at their next release.

## Design decisions worth naming

- **Guard script hosted in `metanorma/ci` and `curl`-fetched at run time** (rather than a second `actions/checkout` of `metanorma/ci`, or inlining ~200 lines of Ruby into yaml). Trade-off: adds a network dep on raw.githubusercontent.com; keeps script version-controlled and updates on `main` propagate automatically. The `test -s` after `curl` fails-loud if the fetch is empty.
- **Guard defaults on** rather than the `enable_breaking_change_check: false` shape from Option 3. Rationale from the ticket body: the guard exists to catch the maintainer who *didn't think about it*; an opt-in flag selects exactly those who already would have. Option 1 wins the guard's actual purpose.
- **Per-run opt-out flag, not per-repo config**. Simpler, auditable in run inputs, forces the maintainer to affirmatively re-run rather than silently skip. Cost: false-positives require the maintainer to know the flag exists (mitigated by the summary's "What to do" section naming it).
- **Advisory-only `gem-compare`**. Failure of the rubygems fetch (network issue, missing gem, etc.) does not fail the guard. Consistent with the ticket's "the guard must not itself become a CI reliability problem."
- **`fetch-depth: 0`** rather than a shallow-fetch strategy. Simpler; typical gem repos are <100 MB. If payload cost ever matters on very large repos, the guard's own `git describe` + `git ls-tree` calls could be adapted for shallower fetches.

## Ship-and-follow-up posture

Per the ticket body's option ranking (`1 → 3 → 2` preference), Option 1 is the intended landing. Filing this without waiting for further maintainer review — the ticket has sat since 2025-10-03 without engagement, and the ask-forgiveness pattern is established for cimas/ci work per the [rehabilitation SSOT](https://github.com/metanorma/cimas/blob/main/plans/cimas-revival-and-release-workflow-realignment.md). If any downstream maintainer objects, revert is a single-file PR; the opt-out flag handles the false-positive class in the meantime.

🤖
