### PR TITLE
master rubocop: add plugins + align TargetRubyVersion with #274 (refs #332)

### DIFF
--- a/cimas-config/gh-actions/master/.rubocop.yml
+++ b/cimas-config/gh-actions/master/.rubocop.yml
@@ -1,8 +1,20 @@
 inherit_from:
   - https://raw.githubusercontent.com/riboseinc/oss-guides/main/ci/rubocop.yml
 
+# Rubocop plugins enabled centrally so every metanorma-org gem picks them up
+# on cimas sync — best practice belongs at the shared-template layer, not
+# per-repo. Per ronaldtse feedback on metanorma/ci#332.
+plugins:
+  - rubocop-rspec
+  - rubocop-performance
+  - rubocop-rake
+
 # local repo-specific modifications
 # ...
 
 AllCops:
-  TargetRubyVersion: 3.4
+  # 3.3 matches the org-wide minimum being pushed via #274 (Raise minimum
+  # Ruby version to 3.3 due to EOL of 3.2 on 2026-03-31). Was 3.4 before
+  # this commit — 3.4 was above the org's stated minimum and would have
+  # applied Rubocop rules that fail-close on gems still targeting 3.3.
+  TargetRubyVersion: 3.3


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/pull/332

## Summary

Phase 1 of the [`ci#332`](https://github.com/metanorma/ci/pull/332) follow-up per @ronaldtse's [technical feedback](https://github.com/metanorma/ci/pull/332#issuecomment-4865308614): enrich the shared rubocop master template so per-repo divergence stops being the mechanism for adopting best-practice cops, and align `TargetRubyVersion` with the org-wide minimum.

Two changes to `cimas-config/gh-actions/master/.rubocop.yml`:

### 1. Add `plugins:` (rubocop-rspec, rubocop-performance, rubocop-rake)

Ronald's feedback on ci#332:

> Especially for the plugins, we should have them enabled for best practice.

These three plugins are generally applicable across the metanorma gem matrix:

- **`rubocop-rspec`** — the spec suites
- **`rubocop-performance`** — the runtime code
- **`rubocop-rake`** — the Rakefiles

Enabling centrally means all consumers pick them up on next cimas sync rather than each repo having to opt in via a divergent `.rubocop.yml`.

### 2. Bump `TargetRubyVersion: 3.4 → 3.3`

The master template was targeting `3.4`, but the org-wide minimum being pushed via [`#274`](https://github.com/metanorma/ci/issues/274) (Raise minimum Ruby version to 3.3 due to EOL of 3.2 on 2026-03-31) is `3.3`. Targeting 3.4 in the shared template while gems still require `>= 3.3.0` in their gemspecs (as ci#274's patches mechanism enforces) makes the master template fail-close on legitimate 3.3-targeted code.

Aligning master's `TargetRubyVersion` with the org's stated minimum keeps the shared template applicable across the current gem matrix. Individual gems can still bump to 3.4 in their own `.rubocop.yml` if they explicitly want the stricter target, but that's an affirmative-in choice rather than fail-close default.

## Why filed as a separate PR from the un-opt-out

The [ci#332 follow-up plan](https://github.com/metanorma/ci/pull/332#issuecomment-4865308614) had three components:

1. **Master template enrichment** — this PR.
2. **Un-opt-out `metanorma-plugin-glossarist`** — needs per-repo work on `metanorma/metanorma-plugin-glossarist`: move remaining local overrides into `.rubocop_todo.yml` + inline `# rubocop:disable` guards, then let cimas sync replace `.rubocop.yml` with the enriched master template. This is `metanorma-plugin-*` territory, owned by @kwkwan; filing as an issue on `metanorma-plugin-glossarist` rather than doing it unilaterally in this PR.
3. **Revert `ci#332`'s rationale block** — once glossarist un-opt-out lands, the rationale documents something that no longer exists. Follow-up PR after phase 2 completes.

Separating them keeps the master template change independently reviewable and mergeable without waiting on the glossarist-repo coordination.

## Blast radius

- **Master template enrichment**: applied to every consumer of `cimas-config/gh-actions/master/.rubocop.yml` on the next cimas sync. Consumers that currently have their own `plugins:` list (glossarist is one) will de-facto see it duplicated until they un-opt-out their local `.rubocop.yml` — no harm, just harmless redundancy.
- **TargetRubyVersion change**: any consumer that currently uses master's `.rubocop.yml` unchanged AND targets Ruby 3.4-specific syntax (via cop enforcement) will find that specific syntax is no longer required. Very small class — 3.4-specific cops are new and few gems have wired code to require them yet.
- **Reversibility**: single-file revert.

## Verification

- `ruby -ryaml -e 'YAML.load_file("cimas-config/gh-actions/master/.rubocop.yml")'` parses cleanly.

🤖
