### PR TITLE
cimas-config: strip 8 externally-transferred entries (per drift-audit #335)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -467,13 +467,11 @@ repositories:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
-  edoxen:
-    remote: ssh://git@github.com/metanorma/edoxen
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # edoxen: transferred to `edoxen/edoxen` (new one-repo org created to
+  # receive it). Surfaced by cimas-drift-audit MVP (metanorma/ci#335) on
+  # 2026-07-02 as class (c) external transfer. Now lives at
+  # https://github.com/edoxen/edoxen and is outside cimas-managed scope.
+  # Pre-transfer entry preserved in git history for reference.
   coradoc:
     remote: ssh://git@github.com/metanorma/coradoc
     branch: main
@@ -766,11 +764,12 @@ repositories:
     branch: main
     files:
       .github/workflows/generate.yml: gh-actions/samples/public-docker.yml
-  pdfa-iso-32000-2:
-    remote: ssh://git@github.com/metanorma/pdfa-iso-32000-2
-    branch: main
-    files:
-      .github/workflows/generate.yml: gh-actions/samples/public-docker.yml
+  # pdfa-iso-32000-2: transferred to `pdf-association/spec-pdf-core`
+  # (PDF Association took ownership as the spec's steward). Surfaced by
+  # cimas-drift-audit MVP (metanorma/ci#335) on 2026-07-02 as class (c)
+  # external transfer. Now lives at
+  # https://github.com/pdf-association/spec-pdf-core and is outside
+  # cimas-managed scope. Pre-transfer entry preserved in git history.
   annotated-express:
     remote: ssh://git@github.com/metanorma/annotated-express
     branch: main
@@ -995,20 +994,16 @@ repositories:
       default/.github/workflows/docker.yml: gh-actions/samples/docker.yml
       default/.github/workflows/generate.yml: gh-actions/samples/generate.yml
   # other
-  iev:
-    remote: ssh://git@github.com/metanorma/iev
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
-  reeper:
-    remote: ssh://git@github.com/metanorma/reeper
-    branch: master
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # iev: transferred to `glossarist/iev` (moved to the glossarist org
+  # alongside the other IEV tooling). Surfaced by cimas-drift-audit MVP
+  # (metanorma/ci#335) on 2026-07-02 as class (c) external transfer.
+  # Now lives at https://github.com/glossarist/iev and is outside
+  # cimas-managed scope. Pre-transfer entry preserved in git history.
+  # reeper: transferred to `lutaml/reeper` (moved to the lutaml org).
+  # Surfaced by cimas-drift-audit MVP (metanorma/ci#335) on 2026-07-02
+  # as class (c) external transfer. Now lives at
+  # https://github.com/lutaml/reeper and is outside cimas-managed scope.
+  # Pre-transfer entry preserved in git history.
   metanorma-registry:
     remote: ssh://git@github.com/metanorma/metanorma-registry
     branch: master
@@ -1027,13 +1022,11 @@ repositories:
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
-  vectory:
-    remote: ssh://git@github.com/metanorma/vectory
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # vectory: transferred to `claricle/vectory` (new claricle org created
+  # to receive it). Surfaced by cimas-drift-audit MVP (metanorma/ci#335)
+  # on 2026-07-02 as class (c) external transfer. Now lives at
+  # https://github.com/claricle/vectory and is outside cimas-managed scope.
+  # Pre-transfer entry preserved in git history.
   suma:
     remote: ssh://git@github.com/metanorma/suma
     branch: main
@@ -1041,13 +1034,11 @@ repositories:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
-  xml-c14n:
-    remote: ssh://git@github.com/metanorma/xml-c14n
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # xml-c14n: transferred to `lutaml/canon` (moved to the lutaml org and
+  # renamed to `canon`). Surfaced by cimas-drift-audit MVP
+  # (metanorma/ci#335) on 2026-07-02 as class (c) external transfer.
+  # Now lives at https://github.com/lutaml/canon and is outside
+  # cimas-managed scope. Pre-transfer entry preserved in git history.
   # rfc
   rfc-divination-cfapi:
     remote: ssh://git@github.com/metanorma/rfc-divination-cfapi
@@ -1176,13 +1167,11 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-  oscal-ruby:
-    remote: ssh://git@github.com/metanorma/oscal-ruby
-    branch: main
-    files:
-      .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/master/rake.yml
-      .github/workflows/release.yml: gh-actions/master/release.yml
+  # oscal-ruby: transferred to `lutaml/oscal` (moved to the lutaml org
+  # and renamed). Surfaced by cimas-drift-audit MVP (metanorma/ci#335)
+  # on 2026-07-02 as class (c) external transfer. Now lives at
+  # https://github.com/lutaml/oscal and is outside cimas-managed scope.
+  # Pre-transfer entry preserved in git history.
   sts-ruby:
     remote: ssh://git@github.com/metanorma/sts-ruby
     branch: main
@@ -1194,10 +1183,13 @@ repositories:
     remote: ssh://git@github.com/metanorma/pngcheck-ruby
     branch: main
     files: []
-  emf2svg-ruby:
-    remote: ssh://git@github.com/metanorma/emf2svg-ruby
-    branch: main
-    files: []
+  # emf2svg-ruby: transferred to `claricle/emf2svg-ruby` (moved to
+  # claricle org, same as vectory). Surfaced by cimas-drift-audit MVP
+  # (metanorma/ci#335) on 2026-07-02 as class (c) external transfer.
+  # Now lives at https://github.com/claricle/emf2svg-ruby and is outside
+  # cimas-managed scope. Pre-transfer entry preserved in git history.
+  # (Prior entry already had `files: []` — no active sync, but the
+  # tracking claim was stale.)
   metanorma-plugin-lutaml:
     remote: ssh://git@github.com/metanorma/metanorma-plugin-lutaml
     branch: main


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300
Refs https://github.com/metanorma/ci/pull/335

## Summary

Batched strip of the **8 external-transfer** entries surfaced by the [first drift-audit run](https://github.com/metanorma/ci/issues/300#issuecomment-4866395661) via [`ci#335`](https://github.com/metanorma/ci/pull/335). Each of these repos was transferred out of the `metanorma` org and now lives in a different org; the cimas.yml entries had been silently push-failing every wave since the transfers happened.

## What's stripped

Same shape as [`ci#329`](https://github.com/metanorma/ci/pull/329)'s `atmospheric` strip — each entry replaced with a 4-6 line comment block noting the new location and referencing the audit finding. Pre-transfer entries remain in git history.

| Repo | Transferred to | Notes |
|---|---|---|
| `edoxen` | [`edoxen/edoxen`](https://github.com/edoxen/edoxen) | New one-repo org, atmospheric-pattern |
| `emf2svg-ruby` | [`claricle/emf2svg-ruby`](https://github.com/claricle/emf2svg-ruby) | Moved to claricle org (same as vectory) |
| `iev` | [`glossarist/iev`](https://github.com/glossarist/iev) | Moved to glossarist org (alongside IEV tooling) |
| `oscal-ruby` | [`lutaml/oscal`](https://github.com/lutaml/oscal) | Moved to lutaml org + renamed |
| `pdfa-iso-32000-2` | [`pdf-association/spec-pdf-core`](https://github.com/pdf-association/spec-pdf-core) | PDF Association took stewardship |
| `reeper` | [`lutaml/reeper`](https://github.com/lutaml/reeper) | Moved to lutaml org |
| `vectory` | [`claricle/vectory`](https://github.com/claricle/vectory) | New claricle org created to receive it |
| `xml-c14n` | [`lutaml/canon`](https://github.com/lutaml/canon) | Moved to lutaml org + renamed to `canon` |

## Verification

Rerunning the drift-audit URL-drift phase confirms all 8 are gone from the findings:

```
$ PHASE_2_URL_DRIFT_ONLY=1 ruby .github/scripts/cimas-drift-audit.rb | grep '\['
  metanorma-model-m3d: [warning c] renamed within metanorma → metanorma-model-m3aawg
  metanorma-model-rsd: [warning c] renamed within metanorma → metanorma-model-ribose
  mn-samples-mlit: [warning c] renamed within metanorma → mn-samples-plateau
  metanorma-ietf-data: [warning c] renamed within metanorma → ietf-data-importer
  iso-10303: [error d] branch drift: cimas.yml says main, GH default is mn/main
```

**From 13 findings → 5**. All remaining findings are either **internal renames** (4 warnings — will address in a follow-up PR) or the **`iso-10303` branch drift** (deferred pending confirmation that `mn/main` is deliberate).

## What's NOT in this PR

- **Internal renames (4)**: `metanorma-model-m3d` → `metanorma-model-m3aawg`, `metanorma-model-rsd` → `metanorma-model-ribose`, `mn-samples-mlit` → `mn-samples-plateau`, `metanorma-ietf-data` → `ietf-data-importer`. These are warnings (redirects still work), and each needs a `cimas.yml` update of the key + `remote:` URL. Batch follow-up PR.
- **`iso-10303` `mn/main` default branch**: unusual default-branch name; probably deliberate. Deferred pending @ronaldtse confirmation before touching.
- **`metanorma-plugin-glossarist:.rubocop.yml`** flag: in-flight via [`glossarist#78`](https://github.com/metanorma/metanorma-plugin-glossarist/issues/78) (assigned @kwkwan).

## Design decisions

- **Batched strip PR** rather than 8 separate PRs. Each strip is atomic and reviewable; batching reduces the review overhead for a class of pure-hygiene changes. Reversibility is one-file revert.
- **Preserve entries in git history via comment blocks** naming the transfer destination + date + audit reference. Same pattern as `ci#329`. Future maintainers reading `git blame` see the transfer context; drift-audit sees the entries are no longer active.
- **Ask-forgiveness merge**. These are unambiguous transfers with clear evidence (redirect surfaced via `gh api`). No maintainer input needed to determine the correct action.

🤖
