### PR TITLE
cimas-master: add least-privilege permissions: to 6 caller templates

### DIFF
--- a/cimas-config/gh-actions/master/automerge.yml
+++ b/cimas-config/gh-actions/master/automerge.yml
@@ -18,6 +18,13 @@ on:
     types:
       - completed
   status: {}
+
+# Least-privilege: pascalgn/automerge-action merges PRs with GITHUB_TOKEN,
+# which requires contents:write (merge) and pull-requests:write.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/cimas-config/gh-actions/master/notify.yml
+++ b/cimas-config/gh-actions/master/notify.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [ tests-passed, release-passed ]
 
+# Least-privilege: mn-processor-notify.yml only checks out and dispatches to
+# other repos via pat_token; GITHUB_TOKEN needs no write scopes.
+permissions:
+  contents: read
 
 jobs:
   notify:

--- a/cimas-config/gh-actions/master/rake-flavor.yml
+++ b/cimas-config/gh-actions/master/rake-flavor.yml
@@ -6,6 +6,11 @@ on:
     tags: [ v* ]
   pull_request:
 
+# Least-privilege: the called mn-processor-rake.yml already tops out at
+# contents:read (its tests-passed dispatch uses pat_token); match that ceiling.
+permissions:
+  contents: read
+
 jobs:
   notify:
     uses: metanorma/ci/.github/workflows/mn-processor-rake.yml@main

--- a/cimas-config/gh-actions/master/release.yml
+++ b/cimas-config/gh-actions/master/release.yml
@@ -12,6 +12,12 @@ on:
   repository_dispatch:
     types: [ do-release ]
 
+# Least-privilege ceiling for the called rubygems-release.yml: its release job
+# needs contents:write (git tag push) and id-token:write (OIDC Trusted Publishing).
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main

--- a/cimas-config/gh-actions/master/release_github_packages.yml
+++ b/cimas-config/gh-actions/master/release_github_packages.yml
@@ -12,6 +12,14 @@ on:
   repository_dispatch:
     types: [ do-release ]
 
+# Least-privilege ceiling for the called ghpkg-release.yml. contents:write covers
+# the `gem bump --tag --push` step (git tag pushed with GITHUB_TOKEN). packages:write
+# is the idiomatic grant for a GitHub Packages release; the actual `gem push` to
+# rubygems.pkg.github.com authenticates with pat_token, not GITHUB_TOKEN.
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     uses: metanorma/ci/.github/workflows/ghpkg-release.yml@main

--- a/cimas-config/gh-actions/master/release_wo_bundle_install.yml
+++ b/cimas-config/gh-actions/master/release_wo_bundle_install.yml
@@ -12,6 +12,12 @@ on:
   repository_dispatch:
     types: [ do-release ]
 
+# Least-privilege ceiling for the called rubygems-release.yml: its release job
+# needs contents:write (git tag push) and id-token:write (OIDC Trusted Publishing).
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main


### PR DESCRIPTION
## What

Adds an explicit least-privilege top-level `permissions:` block to the six cimas **master caller templates** (`cimas-config/gh-actions/master/`) that previously had none. These templates sync to downstream standalone gem repos, so a missing `permissions:` meant each synced repo inherited the over-broad default `GITHUB_TOKEN` and got flagged by CodeQL `actions/missing-workflow-permissions`.

Each ceiling is sized to what the called reusable workflow actually needs (the caller's top-level `permissions:` caps the reusable's `GITHUB_TOKEN`):

| Template | Permissions | Why |
|---|---|---|
| `release.yml`, `release_wo_bundle_install.yml` | `contents: write` + `id-token: write` | `rubygems-release.yml` release job: git tag push + OIDC Trusted Publishing |
| `release_github_packages.yml` | `contents: write` + `packages: write` | `ghpkg-release.yml`: tag push via GITHUB_TOKEN; `gem push` uses `pat_token` |
| `notify.yml` | `contents: read` | `mn-processor-notify.yml`: dispatch via `pat_token` only |
| `rake-flavor.yml` | `contents: read` | `mn-processor-rake.yml` already tops at `contents: read` |
| `automerge.yml` | `contents: write` + `pull-requests: write` | `pascalgn/automerge-action` merges PRs via GITHUB_TOKEN |

`master/rake.yml` already carried `contents: write` and is unchanged. Also fixes a pre-existing missing-EOF-newline in `release_github_packages.yml`.

## Context / scope note

This originated from a `metanorma/pubid` hand-off asking to fix the "source templates" behind pubid's `generic-rake.yml` / `rubygems-release.yml`. During investigation:

- `metanorma/ci`'s own reusable `generic-rake.yml` and `rubygems-release.yml` **already** carry least-privilege permissions — no change needed there.
- **pubid is not currently cimas-synced** (`cimas.yml` lists it `PENDING-READD`, gated on #300 Gap 2), and its workflows are pubid-local + diverged — so no `metanorma/ci` change reaches pubid today.
- The genuine upstream gap was these master caller templates, which this PR closes for every downstream **standalone** repo on its next sync.

pubid's own 5 alerts are addressed separately by hardening pubid's local workflows directly (safe while sync is paused) — tracked out-of-band, not part of this PR.

## Validation

Repo CI is `yamllint` + `actionlint` + `shellcheck` (no rspec). Locally verified: all 6 files parse as valid YAML with the intended scopes; no trailing whitespace, lines ≤140, files end with a newline; only the 6 templates changed. yamllint/actionlint run in CI on push.