### PR TITLE
cimas-config: strip DGGS2ISO-19170 (deleted, first scheduled drift-audit finding)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -844,12 +844,10 @@ repositories:
     files:
       .github/workflows/docker.yml: gh-actions/samples/public-docker.yml
       .github/workflows/generate.yml: gh-actions/samples/public-generate.yml
-  DGGS2ISO-19170:
-    remote: ssh://git@github.com/metanorma/DGGS2ISO-19170
-    branch: master
-    files:
-      .github/workflows/docker.yml: gh-actions/samples/public-docker.yml
-      .github/workflows/generate.yml: gh-actions/samples/public-generate.yml
+  # DGGS2ISO-19170: repo deleted from `metanorma` org (returns 404).
+  # Surfaced by the first scheduled cimas-drift-audit run on 2026-07-04
+  # (metanorma/ci#341) as class (a) — see the tracking issue at
+  # metanorma/ci#342. Pre-delete entry preserved in git history.
   C-17-Publication:
     remote: ssh://git@github.com/metanorma/C-17-Publication
     branch: main
@@ -1491,7 +1489,7 @@ groups:
   - iso-19115-3
   - iso-19626-1
   - iso-tc184-sc4
-  - DGGS2ISO-19170
+  # - DGGS2ISO-19170  (stripped: repo deleted from metanorma org; see ci#342)
   - ogc-dggs-xmi
   apps:
   - packed-mn


### PR DESCRIPTION
Refs #340 #341 #342

## Summary

First finding actioned from the newly-scheduled cimas-drift-audit workflow ([ci#341](https://github.com/metanorma/ci/pull/341)).

- **Class**: (a) repo deleted — `metanorma/DGGS2ISO-19170` returns 404
- **Surfaced by**: the first scheduled audit run 2026-07-04 (see [ci#342](https://github.com/metanorma/ci/issues/342) — the auto-created tracking issue)
- **Action**: strip the entry from cimas.yml + strip the group-membership line. Pre-delete entry preserved in git history.

## Same shape as prior strips

Same pattern as [ci#329](https://github.com/metanorma/ci/pull/329) (atmospheric), [ci#336](https://github.com/metanorma/ci/pull/336) (8 external transfers), [ci#337](https://github.com/metanorma/ci/pull/337) (4 stale duplicates). The scheduled audit is now the surfacing mechanism — the strip pattern is unchanged.

## Verification

YAML parses cleanly. Next scheduled audit run (Wed 09:00 UTC) will confirm the finding is gone.

🤖