### PR TITLE
gap1: parametric rake.yml.erb + migrate 3 consumers + fix drift-audit read_template bug

### DIFF
--- a/.github/scripts/cimas-drift-audit.rb
+++ b/.github/scripts/cimas-drift-audit.rb
@@ -31,7 +31,7 @@ require "json"
 require "open3"
 
 CIMAS_YML_PATH = "cimas-config/cimas.yml"
-GH_ACTIONS_DIR = "cimas-config/gh-actions"
+CIMAS_CONFIG_DIR = "cimas-config"
 
 # ---------- Data model ----------
 
@@ -378,7 +378,7 @@ end
 # Reads a template file from the local ci checkout's cimas-config directory.
 # Returns the raw content string, or nil if the template doesn't exist.
 def read_template(template_path)
-  full = File.join(GH_ACTIONS_DIR, template_path)
+  full = File.join(CIMAS_CONFIG_DIR, template_path)
   return nil unless File.exist?(full)
 
   File.read(full, encoding: "UTF-8")

--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -20,8 +20,15 @@ repositories:
     branch: main
     files:
       .rubocop.yml: gh-actions/master/.rubocop.yml
-      .github/workflows/rake.yml: gh-actions/inkscape/rake.yml
+      .github/workflows/rake.yml: gh-actions/master/rake.yml.erb
       .github/workflows/release.yml: gh-actions/master/release_wo_bundle_install.yml
+    with:
+      # First real consumer of the metanorma/ci#300 Gap 1 `with:` mechanism.
+      # metanorma's live rake.yml has `private-fonts: true` (added in
+      # 2fadd6b3, re-added in 6b113fea per Gap 1's motivating example);
+      # cimas can now render this from cimas.yml rather than requiring
+      # manual re-addition after each sync.
+      private-fonts: true
   metanorma-utils:
     remote: ssh://git@github.com/metanorma/metanorma-utils
     branch: main
@@ -114,9 +121,10 @@ repositories:
       # has since been moved back to the gated rubygems-release.yml@main path
       # (June 2026), so the cimas.yml opt-out is stale. Template note: the
       # original was gh-actions/plantuml/rake.yml; plantuml/ was removed in
-      # 1c8696e — using inkscape/rake.yml as the closest substitute (same as
-      # isodoc). Swap if the wave PR shows substantive divergence vs live.
-      .github/workflows/rake.yml: gh-actions/inkscape/rake.yml
+      # 1c8696e; used inkscape/rake.yml as substitute (matches isodoc); now
+      # migrated to the parametric master/rake.yml.erb (metanorma/ci#300 Gap 1),
+      # which produces byte-identical output when `with:` is empty.
+      .github/workflows/rake.yml: gh-actions/master/rake.yml.erb
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   metanorma-iso:
@@ -399,8 +407,9 @@ repositories:
       # isodoc out with "do immediate release without waiting for unit tests
       # pass" — but the per-repo release.yml has since been moved back to the
       # gated rubygems-release.yml@main path (June 2026), so the cimas.yml
-      # opt-out is stale.
-      .github/workflows/rake.yml: gh-actions/inkscape/rake.yml
+      # opt-out is stale. Migrated to the parametric master/rake.yml.erb
+      # (metanorma/ci#300 Gap 1); byte-identical output with `with:` empty.
+      .github/workflows/rake.yml: gh-actions/master/rake.yml.erb
       .github/workflows/release.yml: gh-actions/master/release.yml
       .github/workflows/integration.yml: gh-actions/inkscape/rake-daily.yml
   html2doc:

--- a/cimas-config/gh-actions/master/rake.yml.erb
+++ b/cimas-config/gh-actions/master/rake.yml.erb
@@ -1,0 +1,44 @@
+name: rake
+
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ v* ]
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  rake:
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: <%= with_values.fetch('setup-tools', 'inkscape,ghostscript') %>
+      submodules: <%= with_values.fetch('submodules', true) %>
+      choco-cache: <%= with_values.fetch('choco-cache', true) %>
+<%- if with_values.key?('private-fonts') -%>
+      private-fonts: <%= with_values['private-fonts'] %>
+<%- end -%>
+<%- if with_values.key?('private-fonts-username') -%>
+      private-fonts-username: <%= with_values['private-fonts-username'] %>
+<%- end -%>
+<%- if with_values.key?('setup-inkscape') -%>
+      setup-inkscape: <%= with_values['setup-inkscape'] %>
+<%- end -%>
+<%- if with_values.key?('shell') -%>
+      shell: <%= with_values['shell'] %>
+<%- end -%>
+<%- if with_values.key?('before-setup-ruby') -%>
+      before-setup-ruby: <%= with_values['before-setup-ruby'] %>
+<%- end -%>
+<%- if with_values.key?('after-setup-ruby') -%>
+      after-setup-ruby: <%= with_values['after-setup-ruby'] %>
+<%- end -%>
+<%- if with_values.key?('tests-passed-event') -%>
+      tests-passed-event: <%= with_values['tests-passed-event'] %>
+<%- end -%>
+<%- if with_values.key?('release-event') -%>
+      release-event: <%= with_values['release-event'] %>
+<%- end -%>
+    secrets:
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300
Refs https://github.com/metanorma/cimas/pull/55

## Summary

Two bundled changes:

1. **Gap 1 migration** — new parametric `master/rake.yml.erb` template + migrate the 3 consumers of `inkscape/rake.yml` (metanorma + metanorma-standoc + isodoc) to consume it. `metanorma` gains the `private-fonts: true` override via the new [`cimas#55`](https://github.com/metanorma/cimas/pull/55) `with:` schema. The parametric template's defaults exactly match `inkscape/rake.yml`, so `metanorma-standoc` and `isodoc` produce **byte-identical** output — safe migration.

2. **`cimas-drift-audit.rb` `read_template` bug fix** — the constant `GH_ACTIONS_DIR = "cimas-config/gh-actions"` was concatenated with template paths that already start with `gh-actions/`, producing `cimas-config/gh-actions/gh-actions/...` which never exists → `read_template` returned nil → `classify_file_drift` short-circuited on the nil check → **class (e.2) silent-drift detection was silently broken from the start.** Fixed to `CIMAS_CONFIG_DIR = "cimas-config"` — template_path already carries the `gh-actions/` prefix per cimas.yml convention.

## Empirical impact of the audit fix

With `(e.2)` detection restored, running the full audit against current `cimas.yml` (157 entries) surfaces:

- **1 error**: `iso-10303` class (d) branch drift — known, deferred pending @ronaldtse confirmation
- **242 warnings**: class (e.2) silent template drift previously hidden
- **2 flags**: `coradoc` + `glossarist` class (e.3) — expected

Breakdown of the 242 silent-drift findings by file type:

| File type | Findings |
|---|---|
| `.rubocop.yml` | 55 |
| `.github/workflows/docker.yml` | 58 |
| `.github/workflows/generate.yml` | 42 |
| `.github/workflows/rake.yml` | 21 |
| `.github/workflows/test.yml` | 19 |
| `.github/workflows/release.yml` | 16 |
| other (workflows in `common/`, `templates/base/`, etc.) | 31 |

Most of the drift is **legitimate accumulated drift** — cimas.yml maps these files to templates, the templates have evolved (e.g. `ci#334` enriched master rubocop yesterday, `ci#328` added dev/test-group exclusion to rubygems-release two days ago), and no cimas-sync wave has propagated since. Class (e.2) is doing exactly what it should: surfacing "these repos need a sync wave." Not something the audit can auto-fix; surfaces for maintainer action.

## Empirical validation of the migration

Local ERB rendering confirmed:

- **Empty `with_values`** — `master/rake.yml.erb` renders byte-identical to `gh-actions/inkscape/rake.yml` (verified via `diff` — no differences)
- **`with: private-fonts: true`** — adds exactly one line: `      private-fonts: true`, matching `metanorma`'s LIVE rake.yml sync target

The parametric template exposes 11 optional overrides matching `generic-rake.yml`'s `workflow_call` inputs: `setup-tools`, `submodules`, `choco-cache` (with defaults from `inkscape/rake.yml`), plus `private-fonts`, `private-fonts-username`, `setup-inkscape`, `shell`, `before-setup-ruby`, `after-setup-ruby`, `tests-passed-event`, `release-event` (rendered only when specified in `with:`).

## What ships

**New file:**
- `cimas-config/gh-actions/master/rake.yml.erb` — parametric template, superset of `inkscape/rake.yml`

**Modified files:**
- `cimas-config/cimas.yml`:
  - `metanorma`: `.github/workflows/rake.yml: gh-actions/inkscape/rake.yml` → `gh-actions/master/rake.yml.erb` + `with: private-fonts: true`
  - `metanorma-standoc`: `.github/workflows/rake.yml: gh-actions/inkscape/rake.yml` → `gh-actions/master/rake.yml.erb`
  - `isodoc`: `.github/workflows/rake.yml: gh-actions/inkscape/rake.yml` → `gh-actions/master/rake.yml.erb`
- `.github/scripts/cimas-drift-audit.rb`:
  - `GH_ACTIONS_DIR = "cimas-config/gh-actions"` → `CIMAS_CONFIG_DIR = "cimas-config"`
  - `File.join(GH_ACTIONS_DIR, template_path)` → `File.join(CIMAS_CONFIG_DIR, template_path)`

## Migration safety

- All 3 migrated repos will produce **byte-identical or superset** output vs. their current rake.yml source:
  - `metanorma-standoc`, `isodoc`: identical output (empty `with:` block)
  - `metanorma`: adds `private-fonts: true` line — matches live rake.yml
- Next cimas-sync wave will propagate. Until then, drift-audit surfaces the pending sync as (e.2) warnings (previously hidden, now visible).
- Reversibility: single-file revert on cimas.yml OR delete master/rake.yml.erb.

## What's NOT in this PR

Per the pattern established earlier tonight:

- **Broader (e.2) sync waves** to clear the 242 pending drift warnings — should be a maintainer-driven cimas-sync run, not this PR.
- **cimas gem release** — cimas#55 is on main; local `bundle exec exe/cimas` consumes it directly.
- **README doc updates** in cimas repo for the new `with:` syntax — separate follow-up.

## Related

- [`metanorma/ci#300`](https://github.com/metanorma/ci/issues/300) — parent issue.
- [`metanorma/cimas#55`](https://github.com/metanorma/cimas/pull/55) — cimas mechanism this consumes.
- [`metanorma/ci#341`](https://github.com/metanorma/ci/pull/341) — scheduled drift-audit workflow (will surface the 242 findings on next Wed run).

🤖
