### PR TITLE
gap2: monorepo-per-gem template family + re-add pubid (closes #300)

### DIFF
--- a/.github/workflows/monorepo-per-gem-rake.yml
+++ b/.github/workflows/monorepo-per-gem-rake.yml
@@ -1,0 +1,255 @@
+# Reusable rake workflow for the per-gem monorepo shape:
+# each gem has its OWN Gemfile inside a subdirectory (e.g. `gems/pubid-*`)
+# rather than a single top-level Gemfile with `path:` references (which is
+# what `monorepo-rake.yml` in this repo handles).
+#
+# Distinct from:
+#   - generic-rake.yml     (single-gem repos, the flavour-gem baseline)
+#   - monorepo-rake.yml    (shared Gemfile with path-referenced gems, coradoc-shape)
+#
+# Promoted from `metanorma/pubid`'s local `./.github/workflows/generic-rake.yml`
+# fork on 2026-07-05 as part of metanorma/ci#300 Gap 2. Kept feature-parity
+# with pubid's live behaviour; adopters can migrate off their local forks
+# by consuming this shared reusable via `gh-actions/monorepo/rake.yml.erb`.
+name: monorepo-per-gem-rake
+
+on:
+  workflow_call:
+    inputs:
+      gem_name:
+        description: 'Select gem to test (for monorepo mode)'
+        required: false
+        type: string
+      gem_directory:
+        description: 'Directory containing individual gems'
+        required: false
+        type: string
+        default: 'gems'
+      monorepo:
+        description: 'Enable monorepo mode'
+        required: false
+        type: boolean
+        default: false
+      tests-passed-event:
+        description: 'Name of event sent with repository-dispatch after rake tests are passed successfully'
+        default: 'tests-passed'
+        type: string
+      release-event:
+        description: 'Name of event sent to initiate release'
+        default: 'do-release'
+        type: string
+    secrets:
+      pat_token:
+        required: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      head_tag: ${{ steps.check.outputs.head_tag }}
+      foreign_pr: ${{ steps.check.outputs.foreign_pr }}
+      ruby_matrix: ${{ steps.ruby_matrix.outputs.value }}
+      gems_matrix: ${{ steps.gems_matrix.outputs.value }}
+      combined_matrix: ${{ steps.combined_matrix.outputs.value }}
+      push_for_tag: ${{ steps.push_for_tag.outputs.value }}
+      default_ruby_version: ${{ steps.config.outputs.default_ruby_version }}
+      public: ${{ steps.repo_status.outputs.public }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: retrieve tags
+      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
+
+    - name: set output variables
+      id: check
+      run: |
+        fpr="no"
+        tag=""
+        if [[ "${{ github.ref }}" == refs/heads/* ]]; then
+          tag="$(git tag --points-at HEAD)"
+        elif [[ "${{ github.ref }}" == refs/pull/* ]] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+          fpr="yes"
+        fi
+        echo "foreign_pr=${fpr}"
+        echo "head_tag=${tag}"
+        echo "foreign_pr=${fpr}" >> $GITHUB_OUTPUT
+        echo "head_tag=${tag}" >> $GITHUB_OUTPUT
+
+    - name: Push for tag
+      id: push_for_tag
+      shell: python
+      run: |
+        import os
+        event_name = '${{ github.event_name }}'
+        repository = '${{ github.repository }}'
+        head_tag = '${{ steps.check.outputs.head_tag }}'
+        excluded_events = ['pull_request', 'workflow_dispatch', 'repository_dispatch', 'cron']
+        excluded_repositories = ['metanorma/isodoc', 'metanorma/metanorma-standoc']
+        is_excluded_event = event_name in excluded_events
+        push_condition = event_name == 'push' and (head_tag == '' or repository in excluded_repositories)
+        result = str(not (is_excluded_event or push_condition)).lower()
+        print(f"The result is: {result}")
+        os.system(f"echo value={result} >> {os.environ['GITHUB_OUTPUT']}")
+
+    - id: ruby_matrix
+      run: |
+        value="$(curl -L https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/ruby-matrix.json)"
+        echo "value=$(echo ${value} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+    - if: ${{ inputs.monorepo }}
+      id: gems_matrix
+      run: |
+        # Get list of gems from gems/ directory
+        if [ -d "${{ inputs.gem_directory }}" ]; then
+          gems=$(ls ${{ inputs.gem_directory }}/ | jq -R -s -c 'split("\n")[:-1]')
+        else
+          gems='[]'
+        fi
+        echo "value=${gems}" >> $GITHUB_OUTPUT
+
+    - if: ${{ inputs.monorepo }}
+      id: combined_matrix
+      run: |
+        # Create combined matrix for gems and ruby versions
+        ruby_matrix='${{ steps.ruby_matrix.outputs.value }}'
+        gems_array='${{ steps.gems_matrix.outputs.value }}'
+
+        # Create combined matrix
+        combined=$(echo "$ruby_matrix" | jq --argjson gems "$gems_array" '
+          .ruby as $ruby_configs |
+          .os as $os_list |
+          $gems as $gem_list |
+          {
+            "include": [
+              $gem_list[] as $gem |
+              $ruby_configs[] as $ruby |
+              $os_list[] as $os |
+              {
+                "gem": $gem,
+                "ruby": $ruby,
+                "os": $os
+              }
+            ]
+          }
+        ')
+
+        echo "value=$(echo ${combined} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+    - id: config
+      run: |
+        value="$(curl -L https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/config.json | jq .ruby.version -r)"
+        echo "default_ruby_version=${value}" >> $GITHUB_OUTPUT
+
+    - id: repo_status
+      uses: metanorma/ci/gh-repo-status-action@main
+
+  rake-traditional:
+    name: Test on Ruby ${{ matrix.ruby.version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: prepare
+    if: needs.prepare.outputs.push-for-tag != 'true' && !inputs.monorepo
+    concurrency:
+      group: '${{ github.workflow }}-${{ matrix.os }}-${{ matrix.ruby.version }}-${{ github.head_ref || github.ref_name }}'
+      cancel-in-progress: true
+    continue-on-error: ${{ matrix.ruby.experimental }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix: ${{ fromJson(needs.prepare.outputs.ruby_matrix) }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby.version }}
+        bundler-cache: true
+        rubygems: ${{ matrix.ruby.rubygems }}
+        bundler: ${{ matrix.ruby.bundler }}
+
+    - run: bundle exec rake
+
+    - if: needs.prepare.outputs.public == 'true' && matrix.os == 'ubuntu-latest' && matrix.ruby.version == needs.prepare.outputs.default-ruby-version
+      uses: codecov/codecov-action@v4
+      with:
+        file: coverage/.resultset.json
+
+  rake-monorepo:
+    name: Test ${{ matrix.gem }} on Ruby ${{ matrix.ruby.version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: prepare
+    if: needs.prepare.outputs.push-for-tag != 'true' && inputs.monorepo
+    concurrency:
+      group: '${{ github.workflow }}-${{ matrix.gem }}-${{ matrix.os }}-${{ matrix.ruby.version }}-${{ github.head_ref || github.ref_name }}'
+      cancel-in-progress: true
+    continue-on-error: ${{ matrix.ruby.experimental }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix: ${{ fromJson(needs.prepare.outputs.combined_matrix) }}
+    defaults:
+      run:
+        working-directory: ${{ format('{0}/{1}', inputs.gem_directory, matrix.gem) }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby.version }}
+        bundler-cache: true
+        rubygems: ${{ matrix.ruby.rubygems }}
+        bundler: ${{ matrix.ruby.bundler }}
+        working-directory: ${{ format('{0}/{1}', inputs.gem_directory, matrix.gem) }}
+
+    - run: bundle exec rake
+
+    - if: needs.prepare.outputs.public == 'true' && matrix.os == 'ubuntu-latest' && matrix.ruby.version == needs.prepare.outputs.default-ruby-version
+      uses: codecov/codecov-action@v4
+      with:
+        file: ${{ format('{0}/{1}/coverage/.resultset.json', inputs.gem_directory, matrix.gem) }}
+
+  tests-passed:
+    needs: [rake-traditional, rake-monorepo]
+    if: always() && (needs.rake-traditional.result == 'success' || needs.rake-traditional.result == 'skipped') && (needs.rake-monorepo.result == 'success' || needs.rake-monorepo.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+    - if: ${{ inputs.monorepo }}
+      uses: peter-evans/repository-dispatch@v3
+      name: Tests passed (monorepo)
+      with:
+        token: ${{ secrets.pat_token || github.token }}
+        repository: ${{ github.repository }}
+        event-type: ${{ inputs.tests-passed-event }}
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.tests-passed-event }}", "gem-name": "${{ inputs.gem_name }}"}'
+
+    - if: ${{ !inputs.monorepo }}
+      uses: peter-evans/repository-dispatch@v3
+      name: Tests passed (traditional)
+      with:
+        token: ${{ secrets.pat_token || github.token }}
+        repository: ${{ github.repository }}
+        event-type: ${{ inputs.tests-passed-event }}
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.tests-passed-event }}"}'
+
+    - if: startsWith(github.ref, 'refs/tags/v') && inputs.monorepo
+      name: Repository ready for release (monorepo)
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.pat_token || github.token }}
+        repository: ${{ github.repository }}
+        event-type: ${{ inputs.release-event }}
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.release-event }}", "gem-name": "${{ inputs.gem_name }}"}'
+
+    - if: startsWith(github.ref, 'refs/tags/v') && !inputs.monorepo
+      name: Repository ready for release (traditional)
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.pat_token || github.token }}
+        repository: ${{ github.repository }}
+        event-type: ${{ inputs.release-event }}
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.release-event }}"}'

--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -194,35 +194,24 @@ repositories:
       .rubocop.yml: gh-actions/master/.rubocop.yml
       .github/workflows/rake.yml: gh-actions/master/rake.yml
       .github/workflows/release.yml: gh-actions/master/release.yml
-  # ============================================================================
-  # PENDING-READD: metanorma/pubid (monorepo)  —  gate: metanorma/ci#300 Gap 2
-  # ============================================================================
-  # The monorepo `metanorma/pubid` is IN SCOPE for cimas-sync long-term, but is
-  # CURRENTLY ABSENT from this config because the master rake.yml template
-  # (`uses: metanorma/ci/.github/workflows/generic-rake.yml@main`) does not fit
-  # the monorepo shape (`uses: ./.github/workflows/generic-rake.yml` with
-  # `monorepo: true, gem_directory: gems`). Re-adding the monorepo with the
-  # master template would clobber its monorepo-aware CI on every cimas-sync.
-  #
-  # Re-add when `metanorma/ci#300` Gap 2 lands the `gh-actions/monorepo/*.yml`
-  # sub-template family. The expected re-added entry will use the new
-  # `template: + with:` schema (gated on Gap 1 also) and look roughly like:
-  #
-  #   pubid:
-  #     remote: ssh://git@github.com/metanorma/pubid
-  #     branch: main
-  #     files:
-  #       .rubocop.yml: gh-actions/master/.rubocop.yml
-  #       .github/workflows/rake.yml:
-  #         template: gh-actions/monorepo/rake.yml
-  #         with:
-  #           monorepo: true
-  #           gem_directory: gems
-  #       .github/workflows/release.yml: gh-actions/monorepo/release.yml
-  #
-  # See metanorma/cimas:plans/cimas-revival-and-release-workflow-realignment.md
-  # for the rehabilitation roadmap.
-  # ============================================================================
+  # metanorma/pubid re-added 2026-07-05 after metanorma/ci#300 Gap 2 landed
+  # the `gh-actions/monorepo/*` template family. The rake.yml sync maps to
+  # `gh-actions/monorepo/rake.yml.erb`, which calls the new shared reusable
+  # `metanorma/ci/.github/workflows/monorepo-per-gem-rake.yml` (promoted from
+  # pubid's local `./.github/workflows/generic-rake.yml` fork). On the next
+  # cimas sync pubid's rake.yml `uses:` line switches from the local fork to
+  # the shared reusable; the local `.github/workflows/generic-rake.yml` fork
+  # becomes orphaned (cleanup follow-up — cimas doesn't manage that file).
+  # Per-repo `with:` follows the metanorma/cimas#55 shape.
+  pubid:
+    remote: ssh://git@github.com/metanorma/pubid
+    branch: main
+    files:
+      .rubocop.yml: gh-actions/master/.rubocop.yml
+      .github/workflows/rake.yml: gh-actions/monorepo/rake.yml.erb
+    with:
+      monorepo: true
+      gem_directory: gems
   #
   # DEPRECATED standalone pubid-* repos — removed 2026-06-29 (refs #274, #300 Gap 3):
   # superseded by `metanorma/pubid` monorepo. Their gems on rubygems are now

--- a/cimas-config/gh-actions/monorepo/rake.yml.erb
+++ b/cimas-config/gh-actions/monorepo/rake.yml.erb
@@ -1,0 +1,40 @@
+name: rake
+
+on:
+  push:
+    branches: [ main, master ]
+    tags: [ v* ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  rake:
+    uses: metanorma/ci/.github/workflows/monorepo-per-gem-rake.yml@main
+    with:
+      monorepo: <%= with_values.fetch('monorepo', true) %>
+      gem_directory: <%= with_values.fetch('gem_directory', 'gems') %>
+<%- if with_values.key?('gem_name') -%>
+      gem_name: <%= with_values['gem_name'] %>
+<%- end -%>
+<%- if with_values.key?('setup-tools') -%>
+      setup-tools: <%= with_values['setup-tools'] %>
+<%- end -%>
+<%- if with_values.key?('before-setup-ruby') -%>
+      before-setup-ruby: <%= with_values['before-setup-ruby'] %>
+<%- end -%>
+<%- if with_values.key?('after-setup-ruby') -%>
+      after-setup-ruby: <%= with_values['after-setup-ruby'] %>
+<%- end -%>
+<%- if with_values.key?('tests-passed-event') -%>
+      tests-passed-event: <%= with_values['tests-passed-event'] %>
+<%- end -%>
+<%- if with_values.key?('release-event') -%>
+      release-event: <%= with_values['release-event'] %>
+<%- end -%>
+    secrets:
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Implements **`#300` Gap 2 (monorepo sub-template family)**. Three coordinated changes:

1. **New shared reusable workflow** — `metanorma/ci/.github/workflows/monorepo-per-gem-rake.yml`, promoted from `metanorma/pubid`'s local `./.github/workflows/generic-rake.yml` fork. Byte-identical to pubid's fork; kept feature-parity so pubid's tests continue passing after adoption.
2. **New cimas template** — `cimas-config/gh-actions/monorepo/rake.yml.erb`. Calls the shared reusable via `uses: metanorma/ci/.github/workflows/monorepo-per-gem-rake.yml@main` with per-repo `with:` block (uses [`cimas#55`](https://github.com/metanorma/cimas/pull/55)'s Gap 1 mechanism).
3. **Re-add `pubid` to `cimas-config/cimas.yml`** — resolves the PENDING-READD block that has been sitting since 2026-06-29. Uses `with: monorepo: true, gem_directory: gems`.

## Why three monorepo reusable workflows now exist

The metanorma-org monorepo pattern is not uniform. This PR crystallises three distinct shapes:

| Reusable | Layout | Example consumer |
|---|---|---|
| `generic-rake.yml` (existing) | Single-gem repos | Most metanorma-flavour gems |
| `monorepo-rake.yml` (existing) | One top-level Gemfile with `path:` references to sub-gems | `coradoc` |
| `monorepo-per-gem-rake.yml` **(new)** | Each gem in a subdirectory with its OWN Gemfile | `pubid` (`gems/pubid-*`) |

The two monorepo shapes are structurally different (shared vs per-gem Gemfiles); folding them into one reusable would complicate every consumer. Keeping them as distinct workflows is the honest ergonomic call.

## Naming rationale

**`monorepo-per-gem-rake.yml`** describes the pattern, not the first consumer. `pubid-monorepo-rake.yml` would tie the name to a specific gem; if `pubid` later gets renamed, retired, or a second per-gem monorepo emerges, the descriptive name doesn't need updating.

## Why we're promoting the local fork rather than enriching the shared `generic-rake.yml`

Investigation of `metanorma/pubid`'s local `./.github/workflows/generic-rake.yml` vs `metanorma/ci`'s shared `generic-rake.yml`:

- Pubid's local is **89 lines longer** (243 vs 154), but with **different features**, not a superset.
- Pubid's local **adds**: `monorepo`, `gem_name`, `gem_directory` (monorepo-specific).
- Pubid's local **lacks**: `setup-tools`, `submodules`, `private-fonts`, `choco-cache`, `setup-inkscape`, `shell` (metanorma-flavour-gem features).

Merging the two into a single reusable would either bloat every single-gem consumer with monorepo inputs, or bloat pubid with flavour-gem inputs. Neither is honest. Two distinct reusables with matching-scope inputs is the cleaner factoring.

## Cimas template design

The template exposes the same 11-optional-input surface as `master/rake.yml.erb` from [`ci#344`](https://github.com/metanorma/ci/pull/344), adjusted for the monorepo-per-gem reusable's input list. Defaults chosen for the pubid case (`monorepo: true`, `gem_directory: gems`). Other future adopters override via cimas.yml's per-repo `with:`.

Rendering for pubid (`with: monorepo: true, gem_directory: gems`) verified locally:

```yaml
jobs:
  rake:
    uses: metanorma/ci/.github/workflows/monorepo-per-gem-rake.yml@main
    with:
      monorepo: true
      gem_directory: gems
    secrets:
      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
```

## Impact on pubid on next cimas sync

Pubid's live `.github/workflows/rake.yml` currently calls its LOCAL fork: `uses: ./.github/workflows/generic-rake.yml`. After next cimas sync, it will call the SHARED reusable: `uses: metanorma/ci/.github/workflows/monorepo-per-gem-rake.yml@main`. All other content — job structure, `with:` values, `secrets` — remains byte-identical.

**The local `./.github/workflows/generic-rake.yml` fork becomes orphaned** (unused). cimas doesn't manage that file, so it stays around until manually removed. A small follow-up PR against `metanorma/pubid` should delete it once the shared reusable is confirmed working via a real wave.

## Drift-audit will show the transition state

Until the next cimas sync propagates:

- `pubid:.github/workflows/rake.yml` will surface as a class (e.2) silent-drift finding — expected, resolves on sync.
- `pubid:.rubocop.yml` also shows as class (e.2) — same accumulated-drift class as the other 54 `.rubocop.yml` findings from `ci#334`'s master rubocop enrichment.

Both clear with the next sync wave.

## Files changed

- **New**: `.github/workflows/monorepo-per-gem-rake.yml` (243 lines; promoted from pubid's local; renamed from `generic-rake` to `monorepo-per-gem-rake`; header explains provenance and distinguishes from the other two rake reusables)
- **New**: `cimas-config/gh-actions/monorepo/rake.yml.erb` (39 lines; parametric monorepo rake template)
- **Modified**: `cimas-config/cimas.yml` (replaces the ~30-line PENDING-READD comment block with the actual `pubid:` entry + a small resolution note)

## `#300` status after this PR

| Gap | Status |
|---|---|
| Gap 1 (per-repo `with:` rendering) | ✅ Shipped (`cimas#55`, `ci#344`) |
| **Gap 2 (monorepo sub-template family)** | **✅ Shipped (this PR)** |
| Gap 3 (drift-audit) | ✅ Shipped (`ci#335`, `#338`, `#341`, `#344`, `#345`) |
| Gap 4 (cheaper) | ✅ Shipped 2026-06-30 (`cimas#52`) |
| Gap 4 (full) | ✅ Shipped 2026-07-04 (`cimas#56`) |

**All `#300` gaps now closed.** The cimas rehabilitation roadmap's `#300` chapter is done end-to-end.

## What's next (out of scope here)

- A cimas-sync wave to clear the 242 accumulated drift findings (including pubid's fresh two) — user-scheduled.
- Delete the orphaned `./.github/workflows/generic-rake.yml` from pubid — small follow-up PR against `metanorma/pubid` once the shared reusable is confirmed working.
- Possibly rename `monorepo-rake.yml` (the coradoc-shape one) to `monorepo-shared-gemfile-rake.yml` for symmetry with the new name. Cosmetic; separate PR.

🤖
