### PR TITLE
master/release.yml: revert redundant release_command override (closes ci#349)

### DIFF
--- a/cimas-config/gh-actions/master/release.yml
+++ b/cimas-config/gh-actions/master/release.yml
@@ -23,16 +23,6 @@ jobs:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
-      # Explicit release_command needed since metanorma/ci#314 deprecated
-      # `bundler_cache` (hardcoded to false) — the reusable's release job no
-      # longer runs `bundle install` implicitly via ruby/setup-ruby, so the
-      # default `bundle exec rake release` fires against uninstalled gems.
-      # Surfaced by kwkwan on metanorma-plugin-lutaml#285. Deeper fix
-      # (bundle install inside rubygems-release.yml's release job) tracked
-      # separately.
-      release_command: |
-        bundle install
-        bundle exec rake release
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/349

## Summary

Reverts the `release_command: bundle install && bundle exec rake release` override that was added to the master `release.yml` template at [`f994f4c`](https://github.com/metanorma/ci/commit/f994f4c) on 2026-07-07.

That commit landed as a defense-in-depth response to [Koonwa's comment on `metanorma-plugin-lutaml#285`](https://github.com/metanorma/metanorma-plugin-lutaml/pull/285#discussion_r3517110963) flagging that `do-release` needs `bundle install`. Investigation for [`ci#349`](https://github.com/metanorma/ci/issues/349) discovered that the deeper fix — an explicit `Fresh bundle install` step *inside* `rubygems-release.yml`'s release job — was **already implemented in [`#316`](https://github.com/metanorma/ci/pull/316) on 2026-06-29**, before Koonwa's original comment.

So the master template override is redundant. The reusable's default `release_command: bundle exec rake release` handles it correctly on its own now.

## Effect

- Downstream gems that resync this template on the next cimas wave lose the redundant inner `bundle install`. The reusable at `rubygems-release.yml` still runs `Fresh bundle install (production groups only)` immediately before the `release_command` step (line 281), so release-time bundle resolution remains correct.
- Downstream gems currently carrying the two-liner (from the 2026-07-08 wave PRs, now merged) keep it until their next cimas resync. The redundancy is harmless — an extra ~30 sec `bundle install` per release, no correctness impact.

## Testing

Static analysis only:

- `rubygems-release.yml` line 281 (`Fresh bundle install (production groups only)`) confirmed to run before line 352 (`${{ inputs.release_command }}`) in the release job.
- OIDC path (lines 354-378) bypasses `release_command` entirely by running `gem build` + `gem push` directly — unaffected by this change.

🤖
