### PR TITLE
cimas: add Gemfile.grammar-build variant for metanorma-model-iso (lutaml-xsd)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -238,7 +238,14 @@ repositories:
     remote: ssh://git@github.com/metanorma/metanorma-model-iso
     branch: main
     files:
-      Gemfile: gh-actions/model/Gemfile
+      # model-iso alone among the model repos carries a `.github/workflows/deploy.yml`
+      # (the "Build and Deploy Grammars" workflow) that shells out to
+      # `bundle exec lutaml-xsd build ...`. The `lutaml-xsd` executable dropped
+      # out of the `lutaml` gem's runtime dep chain in the early-July 2026 lutaml
+      # restructuring, so its Gemfile needs `gem "lutaml-xsd"` explicitly.
+      # `Gemfile.grammar-build` is a scoped variant of `gh-actions/model/Gemfile`
+      # for exactly that use case; other model repos keep the plain template.
+      Gemfile: gh-actions/model/Gemfile.grammar-build
       Makefile: gh-actions/model/Makefile
       .github/workflows/make.yml: gh-actions/model/make.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml

--- a/cimas-config/gh-actions/model/Gemfile.grammar-build
+++ b/cimas-config/gh-actions/model/Gemfile.grammar-build
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem "lutaml"
+gem "lutaml-uml"
+# lutaml-xsd is required by repos whose CI runs `bundle exec lutaml-xsd
+# build` for grammar-package generation (currently metanorma-model-iso's
+# "Build and Deploy Grammars" workflow). The lutaml-xsd executable
+# dropped out of the lutaml gem's runtime dep chain in the early-July
+# 2026 lutaml restructuring; before that, plain `gem "lutaml"` transitively
+# provided it. Adding it explicitly here so the sync survives the next
+# lutaml release without silently re-breaking the workflow.
+gem "lutaml-xsd"


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-model-iso/pull/140

## Summary

Adds a scoped Gemfile template variant for `metanorma-model-iso`. The repo's `.github/workflows/deploy.yml` ("Build and Deploy Grammars") shells out to `bundle exec lutaml-xsd build ...`. The `lutaml-xsd` executable dropped out of the `lutaml` gem's runtime dependency chain in the early-July 2026 lutaml restructuring, so the cimas-generated Gemfile needs `gem "lutaml-xsd"` explicitly.

The hotfix on [`metanorma-model-iso#140`](https://github.com/metanorma/metanorma-model-iso/pull/140) added the same line directly to the repo's live `Gemfile` on the `feature/mathml4-grammar` branch — this PR makes the line survive the next cimas sync.

## Change

- **New template** `cimas-config/gh-actions/model/Gemfile.grammar-build`: identical to `gh-actions/model/Gemfile` plus `gem "lutaml-xsd"`.
- **cimas.yml**: model-iso's `Gemfile:` mapping changed from `gh-actions/model/Gemfile` → `gh-actions/model/Gemfile.grammar-build`. Other model repos keep the plain shared template.

## Scope check — only model-iso needs it

Checked which cimas-managed repos actually invoke `lutaml-xsd`:

- `metanorma-model-iso` — has `deploy.yml`; needs the gem.
- `metanorma-model-standoc`, `metanorma-model-un`, `metanorma-model-cc`, `metanorma-model-ogc`, `basicdoc-models`, `metanorma-requirements-models` — no `deploy.yml`; only `make.yml` + `automerge.yml`.
- `plateau-iur-schema-browser` also invokes `lutaml-xsd` but is not cimas-managed and uses a `path:`-mounted local clone of `lutaml/lutaml-xsd`, so unaffected.

Scoping the change to a variant template (rather than adding the gem to the shared `gh-actions/model/Gemfile`) keeps the sibling repos' bundle graphs unchanged.

## Sibling breakage sweep — class is isolated

Checked recent CI on 3 sibling model repos to see whether the CLI-executable-drop hit other lutaml-family binstubs (`lutaml lml generate`, `lutaml-wsd2uml` — both invoked from the shared `Makefile`):

| Repo | `make.yml` last run |
| --- | --- |
| `metanorma-model-standoc` | 2026-07-05 success |
| `basicdoc-models` | 2026-07-16 success |
| `metanorma-requirements-models` | 2026-07-05 success |

So `lutaml` still provides `lutaml` + `lutaml-wsd2uml` — the drop is isolated to `lutaml-xsd`. Nothing else in the class to fix.

🤖
