### PR TITLE
rubygems-release: ci#358 ask #3 (all three) — tag-listener preflight + dispatch disambiguation + rake preflight

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -101,6 +101,92 @@ jobs:
           submodules: ${{ inputs.submodules }}
           token: ${{ secrets.pat_token || github.token }}
 
+      # Ci#358 ask #3: guarantee a tag-listener workflow exists in the caller
+      # repo when the gated-direct relay is expected to publish. Without a
+      # workflow responding to `push:` with `tags: [ v* ]` (typically
+      # `rake.yml` dispatching `do-release` via `repository_dispatch`), the
+      # workflow_dispatch leg tags but never publishes — silent dead-end. The
+      # metanorma-plugin-lutaml v0.7.47–v0.7.50 incident (ci#358) and the
+      # 2026-07-07 flavor-gem rake.yml deletion (restored 2026-07-20, see
+      # metanorma/cimas plans/cimas-revival-and-release-workflow-realignment.md)
+      # were both this class. Runs only when the relay is actually expected:
+      # gated=true + PAT present + workflow_dispatch. If gated=false or no PAT,
+      # publish fires immediately from this same run and no listener is needed.
+      - name: Preflight — verify tag-listener workflow exists
+        if: >-
+          inputs.gated == true &&
+          env.HAVE_PAT_TOKEN == 'true'
+        run: |
+          python3 - <<'PYEOF'
+          import glob
+          import sys
+
+          try:
+              import yaml
+          except ImportError:
+              import subprocess
+              subprocess.check_call([sys.executable, "-m", "pip", "install", "--quiet", "pyyaml"])
+              import yaml
+
+
+          def listens_for_version_tags(path):
+              try:
+                  with open(path) as fh:
+                      data = yaml.safe_load(fh)
+              except (yaml.YAMLError, OSError):
+                  return False
+              if not isinstance(data, dict):
+                  return False
+              # PyYAML 1.1 parses bare `on:` as the boolean True. Handle both.
+              on = data.get(True)
+              if on is None:
+                  on = data.get("on")
+              if not isinstance(on, dict):
+                  return False
+              push = on.get("push")
+              if not isinstance(push, dict):
+                  return False
+              tags = push.get("tags") or []
+              if not isinstance(tags, list):
+                  return False
+              for t in tags:
+                  s = str(t).strip().strip("'").strip('"')
+                  if s.startswith("v"):
+                      return True
+              return False
+
+
+          candidates = sorted(
+              glob.glob(".github/workflows/*.yml") +
+              glob.glob(".github/workflows/*.yaml")
+          )
+          for f in candidates:
+              if listens_for_version_tags(f):
+                  print(f"::notice::tag-listener workflow found: {f}")
+                  sys.exit(0)
+
+          scanned = ", ".join(candidates) if candidates else "(none — no .github/workflows/)"
+          print("::error::No tag-listener workflow found in .github/workflows/.")
+          print("::error::gated=true + PAT + workflow_dispatch defers publish to a")
+          print("::error::downstream `repository_dispatch: do-release` event, which is")
+          print("::error::fired by a workflow responding to `push:` with `tags: [ v* ]`.")
+          print("::error::Without such a workflow this run would tag the repo but never")
+          print("::error::publish — a silent dead-end (see metanorma/ci#358 and the")
+          print("::error::2026-07-07 flavor-gem rake.yml deletion incident).")
+          print("::error::")
+          print(f"::error::Scanned: {scanned}")
+          print("::error::")
+          print("::error::Fix options (pick one):")
+          print("::error::  1. Add `.github/workflows/rake.yml` (or equivalent) that")
+          print("::error::     listens on `push: tags: [ v* ]` and dispatches do-release")
+          print("::error::     — see cimas-managed template gh-actions/master/rake.yml.")
+          print("::error::  2. Set `gated: false` on the caller workflow — publish fires")
+          print("::error::     immediately from this run, no relay needed.")
+          print("::error::  3. Fire release via `repository_dispatch: do-release` from")
+          print("::error::     an external dispatcher (e.g. a cascade from another repo).")
+          sys.exit(1)
+          PYEOF
+
       - if: ${{ env.HAVE_PAT_TOKEN == 'true' }}
         uses: metanorma/ci/gh-rubygems-setup-action@main
         with:

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -378,6 +378,28 @@ jobs:
           bundle config set --local without 'test'
           bundle install --jobs 4 --retry 3
 
+      # Ci#358 ask #3(c): verify `bundle exec rake` resolves before the
+      # release_command (which defaults to `bundle exec rake release`) runs.
+      # metanorma-core proved a repo can silently violate this: rake was
+      # declared only as gemspec dev dep, not the top-level Gemfile — and
+      # bundle install without the development group excluded it. Fixed both
+      # ways (metanorma/ci#363 re-included development, metanorma-core@9e2d9da
+      # added top-level `gem "rake"`). This guard catches the class going
+      # forward with a pointed error instead of the generic
+      # "can't find executable rake for gem rake" from layer 9.
+      #
+      # Runs only when the release_command will actually fire (API-key path,
+      # SHOULD_PUBLISH true, idempotency guard not skipping).
+      - name: Preflight — verify bundle exec rake resolves
+        if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY == 'true'
+        run: |
+          if ! bundle exec rake --version > /dev/null 2>&1; then
+            echo "::error title=Rake not resolvable::bundle exec rake --version failed. release_command 'bundle exec rake release' will die at gem push."
+            echo "::error::Fix: add \`gem \"rake\"\` to this repo's Gemfile top-level (see metanorma-core@9e2d9da for the reference fix). If rake is only in gemspec dev deps, verify the Fresh bundle install step above included the development group (per metanorma/ci#363)."
+            exit 1
+          fi
+          echo "✓ bundle exec rake resolves ($(bundle exec rake --version | head -1))"
+
       # ============ Version bump (workflow_dispatch only) ============
       - name: Bump version
         if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
@@ -524,3 +546,45 @@ jobs:
           repository: ${{ github.repository }}
           event-type: release-passed
           client-payload: '{"ref": "${{ steps.gem-tag-ref.outputs.value }}", "sha": "${{ github.sha }}", "type": "release-passed"}'
+
+      # Ci#358 ask #3(b): the gated dispatch leg (workflow_dispatch with
+      # gated=true + PAT) bumps version + pushes tag but does NOT publish
+      # — publication is deferred to the do-release repository_dispatch
+      # fired by the tag-listener workflow (typically rake.yml) after tests
+      # pass. Without an explicit summary/notice, this run reads green as
+      # if it shipped a gem. Two recent incidents where a green dispatch
+      # leg was misread as a completed release: metanorma-plugin-lutaml
+      # v0.7.47-v0.7.50 (ci#358 origin) and metanorma-core v0.2.2
+      # (2026-07-20). This step's summary + notice make the disambiguation
+      # unambiguous in the run's UI.
+      - name: Dispatch leg summary — publication DEFERRED (this run did NOT publish)
+        if: >-
+          always() &&
+          github.event_name == 'workflow_dispatch' &&
+          env.SHOULD_PUBLISH != 'true'
+        env:
+          GEM_VERSION: ${{ steps.gem-identity.outputs.version || 'unknown' }}
+          GEM_NAME: ${{ steps.gem-identity.outputs.name || 'unknown' }}
+        run: |
+          {
+            echo "# ⚠️ Publication DEFERRED — this run did NOT publish"
+            echo ""
+            echo "This was the **gated dispatch leg** of the release chain (workflow_dispatch with \`gated=true\` + PAT):"
+            echo ""
+            echo "- Version bump ✓"
+            echo "- Tag \`v${GEM_VERSION}\` pushed ✓"
+            echo "- \`gem push\` **NOT run** (\`SHOULD_PUBLISH=false\` by design)"
+            echo ""
+            echo "Publication happens in the \`do-release\` \`repository_dispatch\` run triggered by the tag-listener workflow (typically \`rake.yml\`) after tests pass."
+            echo ""
+            echo "## To confirm the gem is actually published"
+            echo ""
+            echo "1. Watch the \`rake\` workflow run on tag \`v${GEM_VERSION}\`."
+            echo "2. Watch the subsequent \`release\` workflow triggered by \`repository_dispatch: do-release\`."
+            echo "3. Verify with \`gem list -r ${GEM_NAME} -a\` that the new version is on rubygems.org."
+            echo ""
+            echo "## Why this matters"
+            echo ""
+            echo "Two recent incidents where a green dispatch leg was misread as a completed release: metanorma-plugin-lutaml v0.7.47-v0.7.50 (metanorma/ci#358 origin) and metanorma-core v0.2.2 (2026-07-20). Ci#358 ask #3(b) mandates this explicit disambiguation."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=Publication DEFERRED::This gated dispatch leg did NOT publish ${GEM_NAME} ${GEM_VERSION}. Publication happens in the do-release repository_dispatch run. See this run's job summary for confirmation steps."


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/358

## Summary

Implements all three sub-asks of ci#358 ask #3, sharpened by the metanorma-core v0.2.2 release incident (2026-07-20/21):

- **Ask #3(a)** — tag-listener preflight assertion (original ask).
- **Ask #3(b)** — dispatch-leg publication-DEFERRED disambiguation (new).
- **Ask #3(c)** — bundle exec rake preflight (new).

Two-commit history: `58c9fed` (ask 3a) + `afa1934` (asks 3b + 3c).

## Ask #3(a) — tag-listener preflight (existing commit)

`rubygems-release.yml`'s preflight job now refuses to run when the gated-direct relay is expected to publish but the caller repo has no tag-listener workflow (a `.github/workflows/*.yml` responding to `push:` with `tags: [ v* ]`). Without such a workflow, `workflow_dispatch` tags but never publishes — the silent dead-end that hit metanorma-plugin-lutaml v0.7.47-v0.7.50 (ci#358 origin) and the 2026-07-07 flavor-gem `rake.yml` deletion class.

Triggers when: `inputs.gated == true` + PAT present + `event_name == 'workflow_dispatch'`. Skipped when gated=false or no PAT (publish fires immediately, no listener needed). Uses PyYAML to parse `.github/workflows/*.yml` and search for `on.push.tags` entries starting with `v`.

## Ask #3(b) — dispatch-leg disambiguation (new commit)

The gated dispatch leg (workflow_dispatch with gated=true + PAT) correctly bumps + tags but does NOT publish — publication is deferred to the `do-release` `repository_dispatch` fired by the tag-listener workflow after tests pass. Without a signal, the run reads green as if it shipped a gem.

**Two recent incidents where this misread happened**: metanorma-plugin-lutaml v0.7.47-v0.7.50 (ci#358 origin) and metanorma-core v0.2.2 (2026-07-20). Both were "green means published" inversions where a successful dispatch leg was mistaken for a completed release.

New final step in the release job (fires only when `SHOULD_PUBLISH != 'true' && event_name == 'workflow_dispatch'`):

- Writes a `# ⚠️ Publication DEFERRED — this run did NOT publish` block to `$GITHUB_STEP_SUMMARY` (visible in the run's UI right below the workflow name), naming which steps ran (bump ✓, tag ✓, gem push ✗) and the confirmation checklist (watch tag-listener run → watch do-release run → `gem list -r` check).
- Emits `::notice title=Publication DEFERRED::…` for the run's annotation strip.
- Step name itself ("Dispatch leg summary — publication DEFERRED") shows in the job's step list.

## Ask #3(c) — bundle exec rake preflight (new commit)

metanorma-core proved a repo can silently violate the release chain's rake dependency: rake was declared only as gemspec dev dep, not top-level Gemfile, and bundle install without the development group excluded it. The publish leg then died at `bundle exec rake release` with `can't find executable rake for gem rake`.

Fixed both ways since — metanorma/ci#363 re-included the development group in the reusable's bundle install; metanorma-core@9e2d9da added top-level `gem "rake"` to metanorma-core's Gemfile. This guard catches the class going forward with a pointed error naming the reference fix, instead of the generic "can't find executable" from layer 9.

New step right after "Fresh bundle install (excluding test group)":

```bash
if ! bundle exec rake --version > /dev/null 2>&1; then
  echo "::error title=Rake not resolvable::…"
  echo "::error::Fix: add gem \"rake\" to Gemfile top-level (see metanorma-core@9e2d9da). If in gemspec dev deps only, verify bundle install includes development group (per metanorma/ci#363)."
  exit 1
fi
echo "✓ bundle exec rake resolves (…)"
```

Fires only on API-key path (`SHOULD_PUBLISH == 'true' && HAS_API_KEY == 'true'`). OIDC path (`gem build` + `gem push` directly) doesn't use rake and is unaffected.

## Blast radius

Purely additive across the three asks. All fail-fast conditions target specific failure modes that were previously silent or misleading:

- Ask 3(a): known-broken caller (no tag-listener) now fails at preflight instead of tagging + silent dead-end.
- Ask 3(b): correct-but-partial dispatch leg now visibly says "not published" instead of reading green.
- Ask 3(c): dep-missing caller now fails with a pointed error instead of "can't find executable rake for gem rake".

Zero regression on healthy callers: they see one `::notice::` from ask 3(a) or nothing at all.

## Verification

Local test payload for ask 3(a) verified on three caller shapes earlier (metanorma-iso PASS, metanorma-cli PASS, metanorma/ci FAIL as intended). Asks 3(b) and (c) are additive workflow steps with no local test path — they'll exercise on the first workflow_dispatch release after merge.

🤖
