### PR TITLE
rubygems-release: include dev group so bundle exec rake resolves

### DIFF
--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -270,17 +270,26 @@ jobs:
       # or it dies with Bundler::GemNotFound for anything in the Gemfile.
       # Mirrors the preflight job's fresh-resolve step (same flags).
       #
-      # The release job does NOT need development or test groups — the
-      # release path is `gem build` + `gem push`, not running tests. Excluding
-      # those groups eliminates a class of release-blocking resolution
-      # failures where a transitively-pulled dev dependency happens to be
-      # unresolvable mid-rollout (metanorma/ci#258 — the metanorma-taste
-      # incident where its dev dep metanorma-cli's transitive graph was in
-      # flux). Skipping development and test groups closes that gap without
-      # changing what's actually published.
-      - name: Fresh bundle install (production groups only)
+      # The release path is `bundle exec rake release`, which invokes tasks
+      # provided by `bundler/gem_tasks` (`gem build` + `git push --tags` +
+      # `gem push`). That invocation needs `rake` itself — which in almost
+      # every gem is declared `add_development_dependency "rake"`. Excluding
+      # the development group therefore breaks `bundle exec rake release`
+      # with `can't find executable rake for gem rake`. See
+      # metanorma-core run 29732731200 (2026-07-20) for the concrete failure.
+      #
+      # ci#258 (metanorma-taste, dev dep metanorma-cli's transitive graph in
+      # flux) previously motivated excluding development too. That protection
+      # was over-broad — it blocked rake as a side-effect. If a stack-wide
+      # dev-graph flux recurs, handle it at the gem level (pin the offending
+      # dev dep) rather than fleet-wide excluding all dev deps.
+      #
+      # Test group stays excluded — release does not run test suites, and
+      # test frameworks (rspec matchers, capybara drivers, etc.) can be heavy
+      # and are pure overhead here.
+      - name: Fresh bundle install (excluding test group)
         run: |
-          bundle config set --local without 'development test'
+          bundle config set --local without 'test'
           bundle install --jobs 4 --retry 3
 
       # ============ Version bump (workflow_dispatch only) ============


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-core/actions/runs/29732731200

## Summary

The release job's fresh `bundle install` was excluding the `development` group via `bundle config set --local without 'development test'`. That excluded `rake` — which almost every metanorma-stack gem declares as `add_development_dependency "rake"` — so the subsequent `bundle exec rake release` died with:

```
can't find executable rake for gem rake. rake is not currently included in the bundle …
```

Metanorma-core hit this on run 29732731200 (2026-07-20 workflow_dispatch → repository_dispatch: do-release). Its `spec.add_development_dependency "rake", "~> 13.0"` is the standard shape; the same failure applies to any gem where rake is a dev dep and the caller's release_command uses `bundle exec rake release`.

## Fix

Change the release job's `bundle install` from excluding both `development` and `test` to just `test`:

```diff
-      - name: Fresh bundle install (production groups only)
+      - name: Fresh bundle install (excluding test group)
         run: |
-          bundle config set --local without 'development test'
+          bundle config set --local without 'test'
           bundle install --jobs 4 --retry 3
```

- `development` group now installed — `rake` and other release-tooling gems (`bundler`, `gem_tasks` deps) become resolvable.
- `test` group stays excluded — release doesn't run test suites, and test frameworks (rspec matchers, capybara drivers, etc.) are heavy install-time overhead.

## Trade-off vs metanorma/ci#258

Ci#258 (2023 metanorma-taste incident) previously motivated excluding `development` too. In that case, taste's dev dep `metanorma-cli` had a transitive graph that was in flux mid-rollout, blocking `bundle install`. Excluding dev closed that gap.

Two years on, the ci#258-class protection has proven **over-broad**: it collateral-damaged `rake` for every gem shipping the standard `bundle exec rake release` flow. When the reusable was written the assumption was "release path is `gem build` + `gem push`, not running tests" — accurate for what's PUBLISHED, wrong about what's INVOKED. The `bundle exec` invocation itself needs `rake`.

If a stack-wide dev-graph flux recurs, the correct fix is at the gem level (pin the offending dev dep in the affected gem's Gemfile / gemspec) — not fleet-wide excluding all dev deps.

## Downstream effect

Once merged, next cimas wave re-syncs template files, and subsequent releases across the metanorma stack — starting with the pending metanorma-core v0.2.2 completion — will resolve rake cleanly.

metanorma-core v0.2.2 specifically: tag is already pushed (both local and origin). Once this PR merges, I re-dispatch metanorma-core's release workflow with `next_version: skip` (per the workflow's own input semantics — "pass 'skip' to skip 'git tag' and do 'gem push' for the current version") to publish the already-tagged 0.2.2 to rubygems.org. Publishing goes via `secrets.METANORMA_CI_RUBYGEMS_API_KEY` since metanorma-core.gemspec sets no `allowed_push_host`; not the GH Packages path the nist/bsi releases use.

## No caller-template change needed

metanorma-core's Cimas-generated release.yml carries a `release_command: bundle install && bundle exec rake release` bolt-on (from ci#314 which deprecated the reusable's implicit bundler_cache install). That bolt-on inherits the reusable's `.bundle/config`, so after this PR its own `bundle install` will also include dev — rake will resolve on both invocations. No update needed on the caller template.

🤖
