### PR TITLE
Idempotent publish guard for ghpkg-release.yml + rubygems-release.yml (both paths)

### DIFF
--- a/.github/workflows/ghpkg-release.yml
+++ b/.github/workflows/ghpkg-release.yml
@@ -57,6 +57,17 @@ jobs:
       - if: github.event_name == 'workflow_dispatch' && inputs.next_version != 'skip'
         run: gem bump --version ${{ inputs.next_version }} --tag --push
 
+      # Idempotent publish: `gem push` fails when the target version is
+      # already present on the registry. Two ways that happens legitimately:
+      # (1) a manual pre-publish (working around a local credential /
+      # network issue), and (2) the do-release relay double-firing (per
+      # the README's own note that the reusable should tolerate the
+      # second push). Without a guard, either produces a red run despite
+      # the gem being published — a green-means-published inversion.
+      # Treat "already been pushed" as success; propagate everything else.
+      # See metanorma-nist run 29750989944 (2026-07-21) for the failure
+      # that motivated this. Same guard also applies in
+      # rubygems-release.yml.
       - name: publish to GitHub Packages
         env:
           GITHUB_PACKAGES_TOKEN: ${{ secrets.pat_token }}
@@ -70,4 +81,14 @@ jobs:
           bundle exec rake build
           # gem release - don't allow to execute rake tasks
           # rake release - finished with ERROR: too many connection resets
-          gem push --key github --host https://rubygems.pkg.github.com/metanorma pkg/*.gem
+          rc=0
+          push_out=$(gem push --key github \
+            --host https://rubygems.pkg.github.com/metanorma pkg/*.gem 2>&1) || rc=$?
+          echo "$push_out"
+          if [ "$rc" -ne 0 ]; then
+            if printf '%s' "$push_out" | grep -qiE 'already been pushed'; then
+              echo "::notice title=Idempotent publish::Version already on GitHub Packages; treating as success."
+              exit 0
+            fi
+            exit "$rc"
+          fi

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -347,6 +347,13 @@ jobs:
           gem-name: ${{ steps.gem-identity.outputs.name }}
           gem-version: ${{ steps.gem-identity.outputs.version }}
 
+      # Belt-and-suspenders with the pre-check guard above: the pre-check
+      # queries the rubygems API up-front, but a TOCTOU race is possible —
+      # e.g. a manual `gem push` between pre-check and this publish step,
+      # or the do-release relay double-firing where both runs pass their
+      # own pre-check because propagation is slower than the run gap.
+      # Treat "already been pushed" as success; propagate everything else.
+      # Same shape as ghpkg-release.yml's publish guard.
       - if: env.SHOULD_PUBLISH == 'true' && env.HAS_API_KEY == 'true' && env.skip_push != 'true'
         name: Publish to rubygems.org (API Key)
         env:
@@ -358,7 +365,17 @@ jobs:
           :rubygems_api_key: ${RUBYGEMS_API_KEY}
           EOF
           chmod 0600 ~/.gem/credentials
-          ${{ inputs.release_command }}
+          set +e
+          ${{ inputs.release_command }} 2>&1 | tee /tmp/release-out.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            if grep -qiE 'already been pushed|Repushing of gem versions is not allowed' /tmp/release-out.log; then
+              echo "::notice title=Idempotent publish::Version already on rubygems.org; treating as success."
+              exit 0
+            fi
+            exit "$rc"
+          fi
 
       # ============ Publish: OIDC Trusted Publisher path ============
       - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true'
@@ -374,13 +391,27 @@ jobs:
           gem-name: ${{ steps.gem-identity.outputs.name }}
           gem-version: ${{ steps.gem-identity.outputs.version }}
 
+      # Same idempotent guard as the API-key path above — pre-check
+      # gate + post-check treat-as-success on "already been pushed"
+      # covers the TOCTOU race and the relay double-fire.
       - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true' && env.skip_push != 'true'
         name: Build and push gem (OIDC)
         run: |
           gem build *.gemspec
           mkdir -p pkg
           mv *.gem pkg/
-          gem push pkg/*.gem
+          set +e
+          push_out=$(gem push pkg/*.gem 2>&1)
+          rc=$?
+          set -e
+          echo "$push_out"
+          if [ "$rc" -ne 0 ]; then
+            if printf '%s' "$push_out" | grep -qiE 'already been pushed|Repushing of gem versions is not allowed'; then
+              echo "::notice title=Idempotent publish::Version already on rubygems.org; treating as success."
+              exit 0
+            fi
+            exit "$rc"
+          fi
 
       - if: env.SHOULD_PUBLISH == 'true' && env.USE_OIDC == 'true' && env.skip_push != 'true'
         name: Wait for release to propagate

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -270,17 +270,26 @@ jobs:
       # or it dies with Bundler::GemNotFound for anything in the Gemfile.
       # Mirrors the preflight job's fresh-resolve step (same flags).
       #
-      # The release job does NOT need development or test groups — the
-      # release path is `gem build` + `gem push`, not running tests. Excluding
-      # those groups eliminates a class of release-blocking resolution
-      # failures where a transitively-pulled dev dependency happens to be
-      # unresolvable mid-rollout (metanorma/ci#258 — the metanorma-taste
-      # incident where its dev dep metanorma-cli's transitive graph was in
-      # flux). Skipping development and test groups closes that gap without
-      # changing what's actually published.
-      - name: Fresh bundle install (production groups only)
+      # The release path is `bundle exec rake release`, which invokes tasks
+      # provided by `bundler/gem_tasks` (`gem build` + `git push --tags` +
+      # `gem push`). That invocation needs `rake` itself — which in almost
+      # every gem is declared `add_development_dependency "rake"`. Excluding
+      # the development group therefore breaks `bundle exec rake release`
+      # with `can't find executable rake for gem rake`. See
+      # metanorma-core run 29732731200 (2026-07-20) for the concrete failure.
+      #
+      # ci#258 (metanorma-taste, dev dep metanorma-cli's transitive graph in
+      # flux) previously motivated excluding development too. That protection
+      # was over-broad — it blocked rake as a side-effect. If a stack-wide
+      # dev-graph flux recurs, handle it at the gem level (pin the offending
+      # dev dep) rather than fleet-wide excluding all dev deps.
+      #
+      # Test group stays excluded — release does not run test suites, and
+      # test frameworks (rspec matchers, capybara drivers, etc.) can be heavy
+      # and are pure overhead here.
+      - name: Fresh bundle install (excluding test group)
         run: |
-          bundle config set --local without 'development test'
+          bundle config set --local without 'test'
           bundle install --jobs 4 --retry 3
 
       # ============ Version bump (workflow_dispatch only) ============


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-nist/actions/runs/29750989944

## Summary

The `gem push` step in both `ghpkg-release.yml` and `rubygems-release.yml` throws a bare non-zero exit when the target version is already present on the registry. That turns two legitimate scenarios into red runs even though the gem is published — a green-means-published inversion:

1. **Manual pre-publish**: a maintainer hand-publishes a gem while working around a local credential / network issue, then the automated do-release relay fires later and hits `already been pushed`.
2. **Do-release relay double-fire**: the workflow_dispatch leg + the tag-triggered do-release leg both attempt publish; the second loses the race and fails on the duplicate.

The reusables were originally written assuming the pre-check idempotency guard would cover this, but that guard has a TOCTOU race (state can change between check and push), and `ghpkg-release.yml` never had any guard at all — just the bare push.

Metanorma-nist v2.8.9 hit this on run 29750989944 today: the version had been hand-published ~7 min earlier as a workaround, and the automated `do-release` publish then died on the duplicate. The gem is fine on GitHub Packages; the red run is cosmetic but misleading.

## Fix — post-check treat-as-success

Wraps the `gem push` in both reusables with a POST-check that treats `already been pushed` as success and propagates every other exit code unchanged. Runs in addition to (not instead of) the existing pre-check via `gem-idempotent-push-guard-action`.

**`ghpkg-release.yml`** — new guard in the "publish to GitHub Packages" step:

```bash
rc=0
push_out=$(gem push --key github \
  --host https://rubygems.pkg.github.com/metanorma pkg/*.gem 2>&1) || rc=$?
echo "$push_out"
if [ "$rc" -ne 0 ]; then
  if printf '%s' "$push_out" | grep -qiE 'already been pushed'; then
    echo "::notice title=Idempotent publish::Version already on GitHub Packages; treating as success."
    exit 0
  fi
  exit "$rc"
fi
```

**`rubygems-release.yml`** — same shape on both publish paths:

- **API-key path** (line 350-ish): wraps `${{ inputs.release_command }}` via `set +e` + `tee` + `PIPESTATUS[0]` (the release_command is often multi-line via bundler's rake release task, so simple `$( ... )` capture doesn't fit).
- **OIDC path** (line 377-ish): wraps `gem push pkg/*.gem` via `$( ... ) || rc=$?` — simpler because it's a single command.

Both broaden the match to `grep -qiE 'already been pushed|Repushing of gem versions is not allowed'` since rubygems.org sometimes uses the latter phrasing.

## Why post-check instead of just pre-check

The existing `gem-idempotent-push-guard-action` queries the rubygems API before the publish step and sets `env.skip_push=true` on hit. That works for the common case but has a race — anything that publishes the version BETWEEN the pre-check and the publish step (manual `gem push`, another concurrent workflow, propagation lag on the API vs the push endpoint) still trips the raw failure. Post-check catches those.

`ghpkg-release.yml` has no pre-check at all today, so the post-check here is the sole guard for the GH Packages path. Adding a pre-check equivalent (analogous to the rubygems action but for GH Packages) could follow but isn't in this PR's scope — post-check is the minimum viable idempotency there.

## Blast radius

Purely additive. The guard only fires on the "already been pushed" error string; every other failure mode (auth, network, gemspec validation, etc.) propagates unchanged and still red-runs. Real failures stay red; only the specific already-published case turns green.

## Related

- metanorma-nist run 29750989944 (motivating failure, 2026-07-21)
- metanorma/ci#302 (green-means-published observability — this closes one class in that scope)
- metanorma/ci#358 (release-listener preflight — same "silent-vs-real state divergence" family)
- metanorma/ci#363 (the just-merged dev-group fix — sibling in the release-hardening cluster)

Follow-up: SSOT public-mirror entry to append in `metanorma/cimas:plans/cimas-revival-and-release-workflow-realignment.md` per its update discipline; canonical private SSOT already carries this.

🤖
