### PR TITLE
docs(rubygems-release): consumer versioning discipline + propose v1.1.0 immutable tag

### DIFF
--- a/docs/rubygems-release.md
+++ b/docs/rubygems-release.md
@@ -50,6 +50,23 @@ jobs:
 
 The `repository_dispatch: do-release` listener is kept for backward compatibility with consumer rake.yml files that still dispatch it. In the new model the gem is already published by the time do-release fires; the idempotent guard handles the duplicate push.
 
+## Consumer versioning discipline
+
+The example above pins to `@main` for brevity. Production consumers should pin explicitly to one of two shapes:
+
+- **`@v1` (moving tag)** — advances as this workflow evolves. Consumers get improvements automatically at the cost of silent behaviour shifts when the tag moves. Suitable for early-adopter repos willing to react to unannounced changes.
+
+- **`@v1.x` (immutable tags)** — pinned to a specific release cut. Consumers explicitly version-bump when they want new behaviour. Aligned with the maintainer-authority principle: consumers know exactly which reusable version is in their release path, and are the ones who decide when to move to a new one.
+
+Immutable tags never move once cut; the moving `v1` tag tracks the latest immutable `v1.x`. Check `git tag -l` on this repo for the current available immutable tags.
+
+**Current baselines:**
+
+- `v1.0.0` (`7ebab76`, 2026-07-23) — cimas-config cleanup baseline; predates the `#333`/`#370`/`#371` reverts.
+- `v1.1.0` (*proposed on this PR's merge SHA*) — post-`#333`/`#370`/`#371` baseline: atomic publish, no breaking-change heuristic guard. Recommended pin for new consumers and for consumers wanting the current-blessed shape.
+
+Version-bump semantics for this reusable follow SemVer at the reusable-interface level: consumer-facing input additions, deprecations, or behavioural changes trigger minor bumps; bug fixes without input-surface change trigger patch bumps.
+
 ## Inputs
 
 | Input | Required | Default | Description |


### PR DESCRIPTION
Refs https://github.com/metanorma/cimas/issues/68

## Summary

Two-part change:

1. Adds a `## Consumer versioning discipline` section to `docs/rubygems-release.md` (between the existing Usage and Inputs sections). Documents the `@v1` moving vs `@v1.x` immutable pinning strategies for consumers of this reusable, and names the current baselines.

2. Proposes cutting **`v1.1.0`** on this PR's merge SHA, and advancing the moving `v1` tag to the same SHA. Rationale below.

## Rationale for `v1.1.0`

The existing immutable tag `v1.0.0` was cut 2026-07-23 at `7ebab76`, reflecting the cimas-config cleanup baseline of that day. Since then two substantive reverts have shipped:

- `0a8cd6b` — revert of #333 (patch-release breaking-change heuristic guard removal).
- `fd45239` — revert of #370 (gated relay architecture removal — atomic publish now).

Consumers wanting the current-blessed atomic-publish shape as their immutable-pin baseline need a new immutable tag. `v1.0.0` cannot be moved without breaking the immutability guarantee for anyone (cimas-managed or standalone) who already pinned to it.

`v1.1.0` on the merge SHA gives that baseline cleanly. The bump is `minor` rather than `patch` because the reverts removed consumer-facing inputs (`gated`, `SHOULD_PUBLISH` conditional, `acknowledge_breaking_in_patch`) — kept as deprecated no-ops per #371 but semantically-changed at the reusable-interface level.

## Alignment with prior architectural direction (ci#370)

This proposal aligns with the principles from the ci#370 comment thread:

- **Lesson 6** (*"the maintainer knows more about why this release should ship than any heuristic. Tools should inform, not decide."*) — immutable pinning gives each consumer explicit control over which reusable version is in their release path. The tag namespace informs; the consumer decides when to bump. Consumers pinned to `v1.0.0` continue getting the older shape; consumers pinning to `v1.1.0` explicitly opt into the current shape.

- **Lesson 2** (*"Check the blast radius"*) — cutting `v1.1.0` as a new tag rather than moving `v1.0.0` protects the blast radius of every existing pin, cimas-managed or standalone. Non-cimas consumers who pinned to `v1.0.0` continue to get exactly what they pinned to.

## Version-gating stabilisation note

The immutable-pinning discipline documented in the new docs section is **not** a way to keep the reverted `#333` breaking-change guard or the reverted `#370`/`#371` gated-relay architecture alive on any consumer's side beyond their own explicit choice. Both reverts are the current blessed shape. Consumers wanting the current-blessed shape pin to `v1.1.0`; consumers who pinned to `v1.0.0` before the reverts continue to get the older shape until they choose to bump. That's the immutable-tag semantics operating as intended.

Aligned with ci#369's advisory-not-blocking direction for any future version-gating work. The immutable-pinning discipline is architectural stabilisation for consumers, not entrenchment of reverted mechanisms.

## What this PR does NOT do

- Does NOT rewrite the sections of `docs/rubygems-release.md` orphaned by the `#370`/`#371` revert (gated-relay descriptions, publication-DEFERRED behaviour, tag-listener preflight description, etc.). Those sections are stale but out of scope for this PR to keep the review focused. Separate follow-up planned as soon as practical.
- Does NOT propose additional immutable tags beyond `v1.1.0`.
- Does NOT change any reusable workflow behaviour.

## On-merge maintainer actions

On approval and merge:

1. `git tag -a v1.1.0 <merge-sha> -m "v1.1.0 — post-#333/#370/#371 atomic-publish baseline"`
2. `git push origin v1.1.0`
3. `git tag -f v1 <merge-sha>` then `git push origin v1 --force` (advance the moving tag)

## Test plan

- [x] New docs section renders cleanly on GitHub (Markdown list formatting).
- [ ] On merge: cut `v1.1.0` and advance `v1` per the maintainer actions above.
- [ ] Downstream: consumer pin migrations (`metanorma-cc` canaries #1 and #2 currently on `@v1`) can then explicitly re-pin to `@v1.1.0` as follow-up PRs.

🤖
