### PR TITLE
Add yq-setup-action

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -369,6 +369,49 @@ jobs:
       - if: matrix.os == 'ubuntu-latest'
         run: convert -version
 
+  test-yq-action:
+    name: Test yq-setup-action ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v6
+
+      # The Ubuntu image preinstalls yq, so the action would skip its install
+      # path there. Drop it first so each OS covers a different branch:
+      # ubuntu the release-binary download, macos the already-present skip,
+      # windows the chocolatey install.
+      - if: matrix.os == 'ubuntu-latest'
+        run: |
+          yq_path="$(command -v yq || true)"
+          if [ -n "$yq_path" ]; then
+            echo "Removing preinstalled $yq_path"
+            sudo rm -f "$yq_path"
+          fi
+          if command -v yq; then
+            echo "yq still on PATH, the install path would not be exercised"
+            exit 1
+          fi
+
+      - uses: ./yq-setup-action
+
+      # Ubuntu's apt "yq" is an unrelated jq wrapper that reports "yq 3.4.3"
+      # or "yq 0.0.0", so assert we got mikefarah/yq and not the impostor.
+      - shell: python
+        run: |
+          import re, shutil, subprocess, sys
+          yq = shutil.which("yq")
+          if not yq:
+            sys.exit("yq is not on PATH")
+          out = subprocess.run(
+            [yq, "--version"], capture_output=True, text=True
+          ).stdout.strip()
+          print(out)
+          if not re.search(r"version v\d", out):
+            sys.exit("Not mikefarah/yq: {}".format(out))
+
   test-tool-setup-action:
     name: Test tool-setup-action dispatcher ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dependent-rake.yml
+++ b/.github/workflows/dependent-rake.yml
@@ -164,7 +164,7 @@ jobs:
         subprocess.run("bundle add {} --path ..".format(gem_name), check=True, shell=True)
       working-directory: dependent
 
-    - uses: metanorma/ci/tool-setup-action@feature/yq-setup-action
+    - uses: metanorma/ci/tool-setup-action@main
       with:
         setup-tools: ${{ inputs.setup-tools }}
         setup-inkscape: ${{ inputs.setup-inkscape }}

--- a/.github/workflows/dependent-rake.yml
+++ b/.github/workflows/dependent-rake.yml
@@ -164,7 +164,7 @@ jobs:
         subprocess.run("bundle add {} --path ..".format(gem_name), check=True, shell=True)
       working-directory: dependent
 
-    - uses: metanorma/ci/tool-setup-action@main
+    - uses: metanorma/ci/tool-setup-action@feature/yq-setup-action
       with:
         setup-tools: ${{ inputs.setup-tools }}
         setup-inkscape: ${{ inputs.setup-inkscape }}

--- a/.github/workflows/dependent-rake.yml
+++ b/.github/workflows/dependent-rake.yml
@@ -36,7 +36,7 @@ on:
       setup-tools:
         description: >-
           Comma-separated list of tools to install (no spaces):
-          inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick
+          inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick,yq
         type: string
         default: ''
         required: false

--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -33,7 +33,7 @@ on:
       setup-tools:
         description: >-
           Comma-separated list of tools to install (no spaces):
-          inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick
+          inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick,yq
         type: string
         default: ''
         required: false

--- a/.github/workflows/monorepo-rake.yml
+++ b/.github/workflows/monorepo-rake.yml
@@ -49,7 +49,7 @@ on:
       setup-tools:
         description: >-
           Comma-separated list of tools to install (no spaces):
-          inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick
+          inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick,yq
         type: string
         default: ''
         required: false

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Shared GitHub Actions workflows and composite actions for building, testing, and
 | [`ffmpeg-setup-action`](ffmpeg-setup-action/) | Install FFmpeg |
 | [`exiftool-setup-action`](exiftool-setup-action/) | Install ExifTool |
 | [`xml2rfc-setup-action`](xml2rfc-setup-action/) | Install xml2rfc |
+| [`yq-setup-action`](yq-setup-action/) | Install yq |
 | [`native-deps-action`](native-deps-action/) | List native library dependencies |
 | [`change-tmpdir-action`](change-tmpdir-action/) | Change temp directory |
 

--- a/docs/generic-rake.md
+++ b/docs/generic-rake.md
@@ -32,7 +32,7 @@ jobs:
 | `after-setup-ruby` | no | `''` | Command to run after Ruby setup |
 | `shell` | no | `bash` | Shell for running commands |
 | `setup-inkscape` | no | `false` | Legacy — use `setup-tools` instead |
-| `setup-tools` | no | `''` | Comma-separated tools: `inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick` |
+| `setup-tools` | no | `''` | Comma-separated tools: `inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick,yq` |
 | `submodules` | no | `recursive` | Checkout submodules: `true`, `false`, or `recursive` |
 | `private-fonts` | no | `false` | Enable private fonts via fontist-repo-setup |
 | `private-fonts-username` | no | `metanorma-ci` | Username for private fonts repository |

--- a/tool-setup-action/action.yml
+++ b/tool-setup-action/action.yml
@@ -2,13 +2,13 @@ name: 'tool-setup-action'
 description: >-
   Installs CI tools specified by a comma-separated list.
   Supported tools: inkscape, ghostscript, graphviz, libreoffice,
-  xml2rfc, exiftool, ffmpeg, imagemagick.
+  xml2rfc, exiftool, ffmpeg, imagemagick, yq.
   To add a new tool: create its *-setup-action, then add a step here.
 inputs:
   setup-tools:
     description: >-
       Comma-separated list of tools to install (no spaces):
-      inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick
+      inkscape,ghostscript,graphviz,libreoffice,xml2rfc,exiftool,ffmpeg,imagemagick,yq
     default: ''
   setup-inkscape:
     description: 'Legacy flag — use setup-tools instead. Pass "true" to enable.'
@@ -42,3 +42,6 @@ runs:
 
     - if: contains(format(',{0},', inputs.setup-tools), ',imagemagick,')
       uses: metanorma/ci/imagemagick-setup-action@main
+
+    - if: contains(format(',{0},', inputs.setup-tools), ',yq,')
+      uses: metanorma/ci/yq-setup-action@main

--- a/tool-setup-action/action.yml
+++ b/tool-setup-action/action.yml
@@ -44,4 +44,4 @@ runs:
       uses: metanorma/ci/imagemagick-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',yq,')
-      uses: metanorma/ci/yq-setup-action@main
+      uses: metanorma/ci/yq-setup-action@feature/yq-setup-action

--- a/tool-setup-action/action.yml
+++ b/tool-setup-action/action.yml
@@ -44,4 +44,4 @@ runs:
       uses: metanorma/ci/imagemagick-setup-action@main
 
     - if: contains(format(',{0},', inputs.setup-tools), ',yq,')
-      uses: metanorma/ci/yq-setup-action@feature/yq-setup-action
+      uses: metanorma/ci/yq-setup-action@main

--- a/yq-setup-action/action.yml
+++ b/yq-setup-action/action.yml
@@ -5,16 +5,23 @@ runs:
   steps:
     - shell: python
       run: |
-        import sys, os, platform, shutil
+        import sys, os, platform, re, shutil, subprocess
         sys.path.insert(0, os.path.join(os.environ['GITHUB_ACTION_PATH'], '..', '_shared'))
         from tool_runner import get_platform_name, run_commands
 
-        # GitHub-hosted Ubuntu and macOS runners already ship yq, so skip the
-        # install and avoid re-downloading it (and avoid brew relinking a yq
-        # the runner image installed by other means).
-        if shutil.which("yq"):
-          run_commands(["yq --version"])
-          sys.exit(0)
+        # GitHub-hosted Ubuntu and macOS runners already ship mikefarah/yq, so
+        # skip the install there. Match on the version rather than the name:
+        # Ubuntu's apt "yq" is an unrelated jq wrapper reporting "yq 3.4.3",
+        # and that one has to be replaced rather than kept.
+        existing = shutil.which("yq")
+        if existing:
+          version = subprocess.run(
+            [existing, "--version"], capture_output=True, text=True
+          ).stdout.strip()
+          print("{}: {}".format(existing, version))
+          if re.search(r"version v\d", version):
+            sys.exit(0)
+          print("Not mikefarah/yq, installing over it")
 
         platform_name = get_platform_name()
 

--- a/yq-setup-action/action.yml
+++ b/yq-setup-action/action.yml
@@ -1,0 +1,55 @@
+name: 'yq-setup-action'
+description: 'Installs yq (mikefarah/yq) for all OSes'
+runs:
+  using: "composite"
+  steps:
+    - shell: python
+      run: |
+        import sys, os, platform, shutil
+        sys.path.insert(0, os.path.join(os.environ['GITHUB_ACTION_PATH'], '..', '_shared'))
+        from tool_runner import get_platform_name, run_commands
+
+        # GitHub-hosted Ubuntu and macOS runners already ship yq, so skip the
+        # install and avoid re-downloading it (and avoid brew relinking a yq
+        # the runner image installed by other means).
+        if shutil.which("yq"):
+          run_commands(["yq --version"])
+          sys.exit(0)
+
+        platform_name = get_platform_name()
+
+        if platform_name in ("Ubuntu", "Linux"):
+          # Ubuntu's apt "yq" package is an unrelated jq wrapper, so take the
+          # release binary instead. Download unprivileged, then install, so a
+          # failed fetch cannot leave a broken /usr/local/bin/yq behind.
+          machine = platform.machine().lower()
+          arch = {"x86_64": "amd64", "aarch64": "arm64"}.get(machine)
+          if not arch:
+            print("Unsupported Linux architecture: {}".format(machine))
+            sys.exit(1)
+          download = os.path.join(
+            os.environ.get("RUNNER_TEMP", "/tmp"), "yq.download"
+          )
+          run_commands([
+            "curl -fsSL --retry 3 -o {} "
+            "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_{}"
+            .format(download, arch),
+            "sudo install -m 0755 {} /usr/local/bin/yq".format(download),
+            "rm -f {}".format(download),
+            "which yq",
+            "yq --version",
+          ])
+        else:
+          run_commands({
+            "Darwin": [
+              "brew install yq",
+              "yq --version"
+            ],
+            "Windows": [
+              "choco install --no-progress -y yq",
+              "yq --version"
+            ],
+          }.get(platform_name, [
+            "echo 'Unsupported platform: {}'".format(platform_name),
+            "exit 1"
+          ]))


### PR DESCRIPTION
Adds a `yq` setup action, so CI runners can install it.

Windows runners ship no `yq` at all. That breaks dependent tests for repos that need it. `lutaml/lutaml-model` hits this on `ukiryu/ukiryu`, where two smoke specs fail.

## What this does

- Adds `yq-setup-action` for macOS, Windows and Linux.
- Wires `yq` into `tool-setup-action`, so `setup-tools: 'yq'` works.
- Lists `yq` in the `setup-tools` docs of the three rake workflows.
- Adds a `test-yq-action` job covering all three OSes.

## Install per platform

- macOS uses `brew install yq`.
- Windows uses `choco install yq`.
- Linux takes the release binary from mikefarah/yq.

Linux skips apt on purpose. Ubuntu's apt `yq` is an unrelated jq wrapper. It reports `yq 3.4.3` and has no `eval` subcommand.

The action skips the install when `yq` is already there. Ubuntu and macOS images already ship it.

## Test coverage

Each OS leg covers a different branch:

- ubuntu drops the preinstalled `yq` first, so the download path runs.
- macos keeps its preinstalled `yq`, so the skip path runs.
- windows has none, so the chocolatey path runs.

Every leg then asserts we got mikefarah/yq, not the jq wrapper.

## Before merge

The last commit points two refs at this branch, so the PR can be tested end to end. Revert it and restore `@main` before merging.
