### PR TITLE
Reassign CAMOBAP → opoudjis + ronaldtse in cimas.yml + ci-repo-watcher

### DIFF
--- a/.github/workflows/ci-repo-watcher.yml
+++ b/.github/workflows/ci-repo-watcher.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN || secrets.token }}
         title: New repos in ${{ github.repository_owner }} found
-        assignees: CAMOBAP
+        assignees: opoudjis,ronaldtse
         comment: |
           Review new discovered repositories during run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}:
 

--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -3,7 +3,8 @@ settings:
   reviewers:
     - ronaldtse
   assignees:
-    - CAMOBAP
+    - opoudjis
+    - ronaldtse
 
 repositories:
   metanorma-cli:


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/197

## Why

@CAMOBAP left the team in Jan 2025; live workflow assignments still target their handle. Cimas sync PRs and repo-watcher discovery issues have been landing on a departed team member's dashboard.

## Changes

- `cimas-config/cimas.yml:6-7` — `settings.assignees: - CAMOBAP` → list of `opoudjis` + `ronaldtse` (default assignees for every cimas-generated sync PR; opoudjis is the active sync-wave manager, ronaldtse retains oversight).
- `.github/workflows/ci-repo-watcher.yml:52` — `assignees: CAMOBAP` → `assignees: opoudjis,ronaldtse` (targets for auto-created issues when the watcher discovers new repositories in the org). `metanorma/ci/comment-or-create` splits comma-separated per its `action.yml`.

## Non-scope

- Per-repo `release-tag.yml` / `release.yml` mentions of CAMOBAP in child repositories (mnconvert-ruby, mn2pdf-ruby; the historic mn2sts-ruby / sts2mn-ruby entries are unmapped as of `metanorma/ci@95b14b9`). Those are static in-repo files, either dormant or picked up by future cimas syncs propagating this fix.
- Historical provenance comment at `cimas-config/cimas.yml:1084` referencing CAMOBAP's automation on the removed `lapidist` entry is a valid historical note, not an assignee — untouched.

🤖
