### PR TITLE
Add drift-audit registry rows for release-notes opt-out variants

### DIFF
--- a/.github/scripts/cimas-drift-audit.rb
+++ b/.github/scripts/cimas-drift-audit.rb
@@ -124,12 +124,18 @@ VARIANT_REGISTRY = [
     expected_delta_lines: 8,
     note: "Header comment block + one gem line — introduced in ci#353.",
   },
-  # Additions expected once ci#355 (release-notes floor) lands:
-  #   - release_manual_notes.yml vs release.yml
-  #   - release_wo_bundle_install_manual_notes.yml vs
-  #     release_wo_bundle_install.yml
-  # Both introduced in ci#354 for the auto-generated GitHub Release
-  # notes opt-out path.
+  {
+    variant: "cimas-config/gh-actions/master/release_manual_notes.yml",
+    parent: "cimas-config/gh-actions/master/release.yml",
+    expected_delta_lines: 31,
+    note: "Auto-generated GitHub Release notes opt-out — introduced in ci#354, floor landed in ci#355.",
+  },
+  {
+    variant: "cimas-config/gh-actions/master/release_wo_bundle_install_manual_notes.yml",
+    parent: "cimas-config/gh-actions/master/release_wo_bundle_install.yml",
+    expected_delta_lines: 28,
+    note: "Auto-generated GitHub Release notes opt-out (no-bundle-install variant) — introduced in ci#354, floor landed in ci#355.",
+  },
 ].freeze
 
 # ---------- Data model ----------


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/357

## Why

Class (g) drift-audit shipped in ci#357 pinned the release-notes opt-out variants as pending on ci#355 landing. Ci#355 landed on 2026-08-02; this fills in the pins so drift-audit surfaces silent variance in those templates too.

## Changes

Two new rows appended to `VARIANT_REGISTRY` in `.github/scripts/cimas-drift-audit.rb`, replacing the placeholder comment block:

| Variant | Parent | expected_delta_lines |
|---|---|---|
| `cimas-config/gh-actions/master/release_manual_notes.yml` | `cimas-config/gh-actions/master/release.yml` | 31 |
| `cimas-config/gh-actions/master/release_wo_bundle_install_manual_notes.yml` | `cimas-config/gh-actions/master/release_wo_bundle_install.yml` | 28 |

Both introduced in ci#354. Delta computed via `diff -u -b` with header lines filtered (same procedure as the `Gemfile.grammar-build` pin from ci#353).

## Non-scope

- No changes to class (g) detection logic — that shipped in ci#357.
- No changes to any other class (a)–(f).

🤖
