### PR TITLE
cimas.yml: add mn-samples-iso-10303 for ISO 10303 dummy collection sample

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -590,6 +590,14 @@ repositories:
       .github/workflows/generate.yml: gh-actions/samples/public-generate.yml
       .github/workflows/test.yml: gh-actions/samples/test.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
+  mn-samples-iso-10303:
+    remote: ssh://git@github.com/metanorma/mn-samples-iso-10303
+    branch: main
+    files:
+      .github/workflows/docker.yml: gh-actions/samples/docker.yml
+      .github/workflows/generate.yml: gh-actions/samples/generate.yml
+      .github/workflows/test.yml: gh-actions/samples/test.yml
+      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   mn-samples-cc:
     remote: ssh://git@github.com/metanorma/mn-samples-cc
     branch: main


### PR DESCRIPTION
Refs https://github.com/metanorma/suma/issues/107 https://github.com/metanorma/suma/pull/108

## Why

Phase 3 of the suma#107 → metanorma-cli integration arc. The `metanorma/mn-samples-iso-10303` repo was bootstrapped 2026-08-05 with the synthetic dummy ISO 10303 collection fixture (extracted from `metanorma/suma@4bf4891` — the merge of suma#108). Adding it to the cimas sync fleet keeps its GitHub Actions workflows in-band with the samples-family templates.

## Changes

- `cimas-config/cimas.yml` — add a `mn-samples-iso-10303` entry immediately after `mn-samples-iso`, using the simpler mn-samples-ietf-style file mapping (direct workflow paths, no if_public/if_private branching — the repo is public-only).

## Non-scope

- No template changes; this only registers the repo for existing template sync.
- Downstream integration (Phase 4a grammar-census matrix entry on metanorma-cli, Phase 4b in-tree fixture + collection_spec test case on metanorma-cli) filed as separate PRs.

🤖
