### PR TITLE
cimas.yml: add mn-samples-iso-10303 (corrected generate.yml mapping)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -591,6 +591,14 @@ repositories:
       .github/workflows/generate.yml: gh-actions/samples/public-generate.yml
       .github/workflows/test.yml: gh-actions/samples/test.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
+  mn-samples-iso-10303:
+    remote: ssh://git@github.com/metanorma/mn-samples-iso-10303
+    branch: main
+    files:
+      .github/workflows/docker.yml: gh-actions/samples/docker.yml
+      .github/workflows/generate.yml: gh-actions/samples/public-generate.yml
+      .github/workflows/test.yml: gh-actions/samples/test.yml
+      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   mn-samples-cc:
     remote: ssh://git@github.com/metanorma/mn-samples-cc
     branch: main


### PR DESCRIPTION
## Summary

Closes #382 (rework). Supersedes the original mapping with the corrected generate.yml template.

### Fix

The original PR mapped:
```yaml
.github/workflows/generate.yml: gh-actions/samples/generate.yml   # sample-gen reusable caller
```

The bootstrapped `mn-samples-iso-10303/.github/workflows/generate.yml` matches `samples/public-generate.yml` (inline site-generate matrix). Mapping to `samples/generate.yml` would silently rewrite a working bootstrap with a structurally different workflow on the first cimas sync.

### What lands

```yaml
mn-samples-iso-10303:
  remote: ssh://git@github.com/metanorma/mn-samples-iso-10303
  branch: main
  files:
    .github/workflows/docker.yml: gh-actions/samples/docker.yml           # CI testing via sample-docker reusable
    .github/workflows/generate.yml: gh-actions/samples/public-generate.yml  # matches bootstrap shape
    .github/workflows/test.yml: gh-actions/samples/test.yml
    .github/workflows/automerge.yml: gh-actions/master/automerge.yml
```

Public-only pattern (no if_public/if_private branching) — matches the repo's visibility.

### Test plan

- [x] YAML parses
- [x] 152 repositories total (was 151)
- [ ] CI green on this PR
