### PR TITLE
cimas.yml: unmap docker.yml for mn-samples-plateau (restore Firelight)

### DIFF
--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -718,9 +718,12 @@ repositories:
     remote: ssh://git@github.com/metanorma/mn-samples-plateau
     branch: main
     files:
-      .github/workflows/docker.yml:
-        if_public: gh-actions/samples/public-docker.yml
-        if_private: gh-actions/samples/private-docker.yml.erb
+      # .github/workflows/docker.yml intentionally unmapped 2026-08-10 —
+      # this repo maintains a custom Firelight docker.yml (fl-build +
+      # deploy-pages jobs); cimas sync would strip it (as happened
+      # inadvertently in mn-samples-plateau#536 on 2026-07-12). Longer-
+      # term fix: opt-in Firelight support in samples/public-docker.yml
+      # (design ticket to follow, needs @strogonoff input).
       .github/workflows/test.yml: gh-actions/samples/test.yml
     template:
       binding:


### PR DESCRIPTION
Refs [metanorma/mn-samples-plateau#537](https://github.com/metanorma/mn-samples-plateau/issues/537).

## Why

The 2026-07-12 cimas sync in [metanorma/mn-samples-plateau#536](https://github.com/metanorma/mn-samples-plateau/pull/536) inadvertently stripped @strogonoff's local Firelight customizations on `.github/workflows/docker.yml`. Root cause: cimas sync applies the shared `samples/public-docker.yml` template to the mapped file, overwriting whatever local customizations exist.

Anton had customized docker.yml in commit [`94660bd`](https://github.com/metanorma/mn-samples-plateau/commit/94660bd) (2026-03-30, "fix(ops): try to regain custom HTML/CSS overrides") to add `fl-build` (Firelight build matrix) and `deploy-pages` jobs. The July cimas sync replaced 172 lines of custom FL pipeline with the 14-line standard template shape.

## What lands

Unmap `.github/workflows/docker.yml` from the `mn-samples-plateau` entry in `cimas-config/cimas.yml`. Future cimas syncs will no longer touch docker.yml on that repo, so Anton's restored Firelight jobs (restored on `metanorma/mn-samples-plateau@3ef72cd` in a companion commit) will persist across syncs.

`test.yml` mapping stays intact — test.yml wasn't the FL vehicle.

## Follow-up

Longer-term architectural fix: add opt-in Firelight support to `samples/public-docker.yml` so consumers who want FL don't need to maintain a fully forked docker.yml. Design ticket to follow (needs @strogonoff input on the per-repo config shape, anafero-cli pin, deploy conditionality, overrides mechanism).

🤖
