### PR TITLE
standoc-models P3: cimas.yml collapse + reusable workflow + templates

### DIFF
--- a/.github/workflows/standoc-models-make.yml
+++ b/.github/workflows/standoc-models-make.yml
@@ -1,0 +1,211 @@
+name: standoc-models make
+
+# Reusable workflow for metanorma/standoc-models (monorepo consolidation of
+# ex-metanorma-model-* repos, landed via metanorma-core#16). Called by the
+# consumer template at cimas-config/gh-actions/standoc-models/make.yml.
+#
+# Shape: prepare (matrix + path-filter + full-rebuild flag) → grammar-build
+# (conditional) + per-flavor-make (matrix over changed flavors × OS).
+#
+# Path-filter rules:
+#   - push to main / tag / workflow_dispatch → full rebuild (all 16 flavors +
+#     grammar-build)
+#   - PR touching only <flavor>/ subtrees → matrix over changed flavors
+#   - PR touching grammars/ → grammar-build runs; per-flavor unaffected
+#     (flavors consume vendored RNG via opoudjis's manual grammars/copy.sh)
+#   - PR touching root files (.github, README, .gitmodules) → full rebuild
+#     (conservative: cross-cutting change assumed)
+#   - git diff failure (shallow clone, missing base) → full rebuild
+#     (fail-safe: don't let CI report vacuously green)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  # OS matrix + default Ruby version — delegate to the shared reusable used
+  # by generic-rake.yml and model-make.yml. Local-ref (./) is used here
+  # instead of the external-ref @main pattern from model-make.yml — same
+  # repo, same ref as caller, sidesteps the standing-rule question about
+  # @main vs @v1 for intra-repo references. Follow-up: audit and migrate
+  # existing intra-ci external-ref @main usages to local-ref shape.
+  prepare-matrix:
+    uses: ./.github/workflows/prepare-rake.yml
+
+  # Path-filter + full-rebuild flag — custom to standoc-models because the
+  # per-flavor path-filter shape is monorepo-specific.
+  prepare-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_flavors: ${{ steps.filter.outputs.changed_flavors }}
+      grammars_changed: ${{ steps.filter.outputs.grammars_changed }}
+      full_rebuild: ${{ steps.filter.outputs.full_rebuild }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        name: Compute path-filter + full-rebuild flag
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -eu
+
+          # Single source of truth for the 16-flavor list — used to derive
+          # both the all_flavors JSON literal AND the alternation-regex
+          # for path-filter grep. Adding a new flavor requires updating
+          # THIS line only (not three separate sites).
+          FLAVORS_LIST='bipm bsi cc csa gb ieee iho iso itu m3aawg mpfa nist ogc ribose standoc un'
+          all_flavors=$(printf '%s\n' $FLAVORS_LIST | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          FLAVORS_ALT=$(printf '%s\n' $FLAVORS_LIST | paste -sd '|' -)
+
+          # Full rebuild triggers: main-push, tag push, workflow_dispatch.
+          full_rebuild=false
+          case "$EVENT" in
+            push)
+              case "$REF" in
+                refs/heads/main) full_rebuild=true ;;
+                refs/tags/*) full_rebuild=true ;;
+              esac
+              ;;
+            workflow_dispatch) full_rebuild=true ;;
+          esac
+
+          if [ "$full_rebuild" = "true" ]; then
+            changed_flavors="$all_flavors"
+            grammars_changed=true
+          elif [ -z "$BASE_SHA" ]; then
+            # No base SHA (shouldn't happen on PR) — fall through to full
+            # rebuild rather than emit an empty matrix.
+            echo "WARNING: no BASE_SHA — defaulting to full rebuild" >&2
+            full_rebuild=true
+            changed_flavors="$all_flavors"
+            grammars_changed=true
+          elif ! changed_files=$(git diff --name-only "$BASE_SHA"...HEAD 2>&1); then
+            # git diff failed (shallow clone, base force-pushed, etc.) —
+            # fall through to full rebuild rather than silently emit an
+            # empty matrix (which would make CI vacuously green).
+            echo "WARNING: git diff failed — defaulting to full rebuild. Output was: $changed_files" >&2
+            full_rebuild=true
+            changed_flavors="$all_flavors"
+            grammars_changed=true
+          else
+            # PR event: compute path-filter from diff.
+            # Cross-flavor / root-touching detection: any change outside a
+            # single-flavor subtree (or grammars/) triggers full rebuild.
+            # Root files (.github/, README, .gitmodules, LICENSE) fall here.
+            root_or_cross=$(echo "$changed_files" \
+              | grep -vE "^(${FLAVORS_ALT}|grammars)/" \
+              | grep -v '^$' | head -1 || true)
+
+            if [ -n "$root_or_cross" ]; then
+              full_rebuild=true
+              changed_flavors="$all_flavors"
+              grammars_changed=true
+            else
+              # Extract changed flavors from diff paths.
+              flavors=$(echo "$changed_files" | awk -F/ '{print $1}' \
+                | grep -v '^grammars$' | sort -u)
+              if [ -z "$flavors" ]; then
+                changed_flavors='[]'
+              else
+                changed_flavors=$(echo "$flavors" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+              fi
+
+              # Grammars changed?
+              grammars_changed=false
+              if echo "$changed_files" | grep -q '^grammars/'; then
+                grammars_changed=true
+              fi
+            fi
+          fi
+
+          echo "full_rebuild=$full_rebuild" >> "$GITHUB_OUTPUT"
+          echo "changed_flavors=$changed_flavors" >> "$GITHUB_OUTPUT"
+          echo "grammars_changed=$grammars_changed" >> "$GITHUB_OUTPUT"
+
+          echo "=== path filter result ==="
+          echo "full_rebuild: $full_rebuild"
+          echo "changed_flavors: $changed_flavors"
+          echo "grammars_changed: $grammars_changed"
+
+  grammar-build:
+    needs: [prepare-matrix, prepare-filter]
+    if: needs.prepare-filter.outputs.grammars_changed == 'true' || needs.prepare-filter.outputs.full_rebuild == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ needs.prepare-matrix.outputs.default-ruby-version }}
+          bundler-cache: true
+          working-directory: grammars
+
+      - name: Build grammars
+        working-directory: grammars
+        run: ./make.sh
+
+      - name: Verify grammar build output
+        working-directory: grammars
+        shell: bash
+        run: |
+          set -eu
+          # Defensive: trang silently exiting 0 without producing .rng is a
+          # class of failure worth catching at CI time. Analog to the
+          # verify-images check in gh-actions/model/Makefile (ci#302/#303).
+          rnc_count=$(find . -maxdepth 1 -name '*.rnc' | wc -l | tr -d ' ')
+          rng_count=$(find . -maxdepth 1 -name '*.rng' | wc -l | tr -d ' ')
+          if [ "$rng_count" -eq 0 ] && [ "$rnc_count" -gt 0 ]; then
+            echo "ERROR: grammar build produced no .rng despite $rnc_count .rnc sources" >&2
+            exit 1
+          fi
+          echo "grammar-build: $rng_count .rng file(s) present after build (from $rnc_count .rnc source(s))"
+
+  per-flavor-make:
+    needs: [prepare-matrix, prepare-filter]
+    if: needs.prepare-filter.outputs.changed_flavors != '[]' && needs.prepare-filter.outputs.changed_flavors != ''
+    name: Build ${{ matrix.flavor }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      # For PRs, head_ref scopes concurrency to the branch (cancel earlier
+      # in-flight jobs on new commits). For push events, head_ref is empty;
+      # falling back to github.sha means each commit gets its own group (no
+      # cross-commit cancellation), which protects full-rebuild waves on
+      # main from being interrupted by rapid follow-up pushes.
+      group: '${{ github.workflow }}-${{ matrix.flavor }}-${{ matrix.os }}-${{ github.head_ref || github.sha }}'
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: ${{ fromJson(needs.prepare-filter.outputs.changed_flavors) }}
+        os: ${{ fromJson(needs.prepare-matrix.outputs.matrix).os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - if: runner.os == 'Windows'
+        uses: metanorma/ci/choco-cache-action@main
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ needs.prepare-matrix.outputs.default-ruby-version }}
+          bundler-cache: true
+          working-directory: ${{ matrix.flavor }}
+
+      - uses: metanorma/ci/tool-setup-action@main
+        with:
+          setup-tools: 'graphviz'
+
+      - name: Build flavor ${{ matrix.flavor }}
+        working-directory: ${{ matrix.flavor }}
+        run: bundle exec make clean all

--- a/cimas-config/cimas.yml
+++ b/cimas-config/cimas.yml
@@ -239,152 +239,64 @@ repositories:
   # so no entry to remove.
 
   # models
-  metanorma-model-gb:
-    remote: ssh://git@github.com/metanorma/metanorma-model-gb
+  # standoc-models: monorepo consolidation of 16 metanorma-model-* repos.
+  # Landed via metanorma-core#16 (opoudjis + Quark, 2026-08-10). Per-flavor
+  # Makefile + Gemfile mappings sync the 16 subdirectories from the shared
+  # gh-actions/model/* templates. grammars/ has its own Gemfile
+  # (Gemfile.grammar-build variant with lutaml-xsd for grammar packaging).
+  # Repo-level workflows: make.yml (monorepo caller for
+  # standoc-models-make.yml reusable in metanorma/ci), deploy.yml (iso-only
+  # "Build and Deploy Grammars" workflow inherited from ex-model-iso,
+  # retained per opoudjis's directive with monorepo path adaptation),
+  # automerge.yml (standard). 16 old metanorma-model-* repos untouched
+  # pending archival (P4).
+  standoc-models:
+    remote: ssh://git@github.com/metanorma/standoc-models
     branch: main
     files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-iso:
-    remote: ssh://git@github.com/metanorma/metanorma-model-iso
-    branch: main
-    files:
-      # model-iso alone among the model repos carries a `.github/workflows/deploy.yml`
-      # (the "Build and Deploy Grammars" workflow) that shells out to
-      # `bundle exec lutaml-xsd build ...`. The `lutaml-xsd` executable dropped
-      # out of the `lutaml` gem's runtime dep chain in the early-July 2026 lutaml
-      # restructuring, so its Gemfile needs `gem "lutaml-xsd"` explicitly.
-      # `Gemfile.grammar-build` is a scoped variant of `gh-actions/model/Gemfile`
-      # for exactly that use case; other model repos keep the plain template.
-      Gemfile: gh-actions/model/Gemfile.grammar-build
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-standoc:
-    remote: ssh://git@github.com/metanorma/metanorma-model-standoc
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-un:
-    remote: ssh://git@github.com/metanorma/metanorma-model-un
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-mpfa:
-    remote: ssh://git@github.com/metanorma/metanorma-model-mpfa
-    branch: master
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-itu:
-    remote: ssh://git@github.com/metanorma/metanorma-model-itu
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-csa:
-    remote: ssh://git@github.com/metanorma/metanorma-model-csa
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-nist:
-    remote: ssh://git@github.com/metanorma/metanorma-model-nist
-    branch: master
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-iho:
-    remote: ssh://git@github.com/metanorma/metanorma-model-iho
-    branch: master
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-cc:
-    remote: ssh://git@github.com/metanorma/metanorma-model-cc
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  # metanorma-model-m3d: renamed within `metanorma` to `metanorma-model-m3aawg`
-  # (the model tracks the M3AAWG standards body's evolution). Surfaced by
-  # cimas-drift-audit MVP (metanorma/ci#335) on 2026-07-02 as class (c)
-  # internal rename. Stale duplicate — the `metanorma-model-m3aawg:` entry
-  # below already exists with equivalent config; keeping this here would
-  # double-count. Pre-rename entry preserved in git history.
-  metanorma-model-ogc:
-    remote: ssh://git@github.com/metanorma/metanorma-model-ogc
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  # metanorma-model-rsd: renamed within `metanorma` to `metanorma-model-ribose`
-  # (the model tracks the Ribose-branded standard). Surfaced by
-  # cimas-drift-audit MVP (metanorma/ci#335) on 2026-07-02 as class (c)
-  # internal rename. Stale duplicate — the `metanorma-model-ribose:` entry
-  # below already exists with equivalent config; keeping this here would
-  # double-count. Pre-rename entry preserved in git history.
-  metanorma-model-bipm:
-    remote: ssh://git@github.com/metanorma/metanorma-model-bipm
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-ieee:
-    remote: ssh://git@github.com/metanorma/metanorma-model-ieee
-    branch: master
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-bsi:
-    remote: ssh://git@github.com/metanorma/metanorma-model-bsi
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-ribose:
-    remote: ssh://git@github.com/metanorma/metanorma-model-ribose
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
-      .github/workflows/automerge.yml: gh-actions/master/automerge.yml
-  metanorma-model-m3aawg:
-    remote: ssh://git@github.com/metanorma/metanorma-model-m3aawg
-    branch: main
-    files:
-      Gemfile: gh-actions/model/Gemfile
-      Makefile: gh-actions/model/Makefile
-      .github/workflows/make.yml: gh-actions/model/make.yml
+      # Per-flavor Makefile + Gemfile (16 flavors x 2 files = 32 mappings).
+      # All flavors sync the same uniform templates. Any Makefile
+      # improvement (e.g., the verify-images defensive check from ci#302/
+      # #303) lands uniformly across all flavors on next sync.
+      bipm/Gemfile: gh-actions/model/Gemfile
+      bipm/Makefile: gh-actions/model/Makefile
+      bsi/Gemfile: gh-actions/model/Gemfile
+      bsi/Makefile: gh-actions/model/Makefile
+      cc/Gemfile: gh-actions/model/Gemfile
+      cc/Makefile: gh-actions/model/Makefile
+      csa/Gemfile: gh-actions/model/Gemfile
+      csa/Makefile: gh-actions/model/Makefile
+      gb/Gemfile: gh-actions/model/Gemfile
+      gb/Makefile: gh-actions/model/Makefile
+      ieee/Gemfile: gh-actions/model/Gemfile
+      ieee/Makefile: gh-actions/model/Makefile
+      iho/Gemfile: gh-actions/model/Gemfile
+      iho/Makefile: gh-actions/model/Makefile
+      iso/Gemfile: gh-actions/model/Gemfile
+      iso/Makefile: gh-actions/model/Makefile
+      itu/Gemfile: gh-actions/model/Gemfile
+      itu/Makefile: gh-actions/model/Makefile
+      m3aawg/Gemfile: gh-actions/model/Gemfile
+      m3aawg/Makefile: gh-actions/model/Makefile
+      mpfa/Gemfile: gh-actions/model/Gemfile
+      mpfa/Makefile: gh-actions/model/Makefile
+      nist/Gemfile: gh-actions/model/Gemfile
+      nist/Makefile: gh-actions/model/Makefile
+      ogc/Gemfile: gh-actions/model/Gemfile
+      ogc/Makefile: gh-actions/model/Makefile
+      ribose/Gemfile: gh-actions/model/Gemfile
+      ribose/Makefile: gh-actions/model/Makefile
+      standoc/Gemfile: gh-actions/model/Gemfile
+      standoc/Makefile: gh-actions/model/Makefile
+      un/Gemfile: gh-actions/model/Gemfile
+      un/Makefile: gh-actions/model/Makefile
+      # Grammar-build Gemfile (Gemfile.grammar-build variant with
+      # lutaml-xsd for grammar packaging - inherited from ex-model-iso's
+      # grammar-build capability, now hosted at grammars/ in the monorepo).
+      grammars/Gemfile: gh-actions/model/Gemfile.grammar-build
+      # Repo-level workflows.
+      .github/workflows/make.yml: gh-actions/standoc-models/make.yml
+      .github/workflows/deploy.yml: gh-actions/standoc-models/deploy.yml
       .github/workflows/automerge.yml: gh-actions/master/automerge.yml
   basicdoc-models:
     remote: ssh://git@github.com/metanorma/basicdoc-models

--- a/cimas-config/gh-actions/standoc-models/deploy.yml
+++ b/cimas-config/gh-actions/standoc-models/deploy.yml
@@ -1,0 +1,84 @@
+name: Build and Deploy Grammars
+
+# Iso-only "Build and Deploy Grammars" workflow, inherited from ex-
+# metanorma-model-iso and adapted for the standoc-models monorepo layout.
+# Runs the lutaml-xsd grammar-package build + SPA HTML generation + GitHub
+# Pages deploy. Artefact names preserved from original (metanorma-model-
+# iso.lxr / .html) for downstream consumer compatibility. All build steps
+# run with working-directory: iso/ since the source files (scripts,
+# build-config-small.yml, images, Gemfile) preserve their pre-monorepo
+# repo-root paths under the iso/ subdirectory (git filter-repo
+# --to-subdirectory-filter output).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Setup Ruby
+        # Ruby 4.0 preserved from original ex-model-iso deploy.yml. Per
+        # opoudjis 2026-08-10, 4.0 is no longer experimental in the
+        # metanorma stack. Deploy Ruby intentionally may differ from
+        # make.yml's default (3.3.5); if lutaml-xsd or a transitive dep
+        # breaks on 4.0, revisit here.
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+          working-directory: iso
+
+      - name: Fix include paths in rnc files
+        working-directory: iso
+        run: ruby scripts/flatten-include-files.rb
+
+      - name: Build LXR package
+        working-directory: iso
+        run: bundle exec lutaml-xsd build from-config build-config-small.yml --output metanorma-model-iso.lxr
+
+      - name: Generate SPA documentation
+        working-directory: iso
+        run: bundle exec lutaml-xsd spa metanorma-model-iso.lxr --mode inlined --output metanorma-model-iso.html
+
+      - name: Prepare artifact
+        working-directory: iso
+        run: |
+          mkdir -p _site
+          cp metanorma-model-iso.html _site/index.html
+          cp -r images _site/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: iso/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/cimas-config/gh-actions/standoc-models/make.yml
+++ b/cimas-config/gh-actions/standoc-models/make.yml
@@ -1,0 +1,11 @@
+name: make
+
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  make:
+    uses: metanorma/ci/.github/workflows/standoc-models-make.yml@v1


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-core/issues/16.

## Summary

Standoc-models P3 (cimas + CI) for the metanorma-model-* monorepo consolidation. P1/P2 (repo consolidation) landed by opoudjis + Quark on 2026-08-10; this PR completes the cimas + CI repoint per Quark's P3 ask.

## What lands

**cimas.yml**: 16 metanorma-model-* entries collapsed into 1 `metanorma/standoc-models` entry (net -88 lines). Keeps `basicdoc-models` + `metanorma-requirements-models` unchanged (both still standalone submodule sources).

The new entry syncs 36 file mappings:

- 16 flavors × (Gemfile + Makefile) = 32 mappings (uniform templates from `gh-actions/model/*`).
- `grammars/Gemfile` → `gh-actions/model/Gemfile.grammar-build` (inherits from ex-model-iso's lutaml-xsd Gemfile).
- Three workflows: `make.yml` (calls the new reusable), `deploy.yml` (iso-only Build-and-Deploy-Grammars, adapted for monorepo iso/ paths), `automerge.yml` (standard).

**New reusable workflow** `.github/workflows/standoc-models-make.yml`: 4 jobs — `prepare-matrix` (local-ref call to `prepare-rake.yml`), `prepare-filter` (path-filter shell computing `changed_flavors[]` + `grammars_changed` + `full_rebuild`), `grammar-build` (conditional on grammars-touch or full-rebuild), `per-flavor-make` (matrix over `changed_flavors × os`). Full-rebuild triggers: main-push, tag-push, workflow_dispatch, cross-flavor / root-touching PR changes, or git diff failure (fail-safe against shallow-clone edge cases).

**New templates**:

- `cimas-config/gh-actions/standoc-models/make.yml` — caller stub, pins `@v1` per standing-rule discipline (see post-merge tasks below).
- `cimas-config/gh-actions/standoc-models/deploy.yml` — iso-only Build-and-Deploy-Grammars, all steps with `working-directory: iso/` (since ex-model-iso `scripts/`, `build-config-small.yml`, `Gemfile`, `images/` all land under `iso/` via git-filter-repo). Artefact names preserved (`metanorma-model-iso.lxr` / `.html`). Ruby 4.0 preserved per opoudjis (no longer experimental in the stack).

## Post-review fixes applied

Substantive fixes applied via commit amend after `/code-review` pass on the initial commit:

1. **git diff failure → full-rebuild fallback** — no more vacuously-green CI on shallow clone / force-pushed base scenarios.
2. **Concurrency uses `github.sha` for push events** (via `head_ref || sha`), preventing cancellation of in-flight full-rebuild waves by rapid follow-up main-pushes (release / dep-bump / docs-fix cadence).
3. **16-flavor list extracted to `FLAVORS_LIST` shell variable** — avoiding 3-way drift risk between JSON literal + regex + regex. Adding a new flavor requires a single-site edit.
4. **Empty regex alternative simplified** to plain fixed-string grep on `^grammars$`.

Ruby 4.0 in `deploy.yml` retained with a comment noting the intentional divergence from make.yml's default (per opoudjis 2026-08-10).

## Post-merge tasks (opoudjis-manual)

1. **Move v1 tag on metanorma/ci** to include the new reusable:

    ```sh
    git tag -f v1 main && git push origin v1 --force
    ```

    Required before triggering cimas sync on standoc-models, otherwise the deposited `make.yml` template's `@v1` pin will 404 against a `v1` that doesn't yet have the reusable.

2. **Trigger cimas sync on standoc-models** (usual sync invocation) after (1). First push/PR on standoc-models then fires `make.yml` → resolves `@v1` → loads the reusable → runs.

3. **Post-first-run watch**: the initial workflow run on standoc-models will full-rebuild all 16 flavors on the first main-push (full-rebuild trigger). Monitor for per-flavor build breakage; the per-flavor Makefiles were preserved byte-for-byte from the pre-consolidation state via git-filter-repo, so builds should match pre-migration behaviour.

## Non-scope for this PR

- Archival of the 16 old metanorma-model-* source repos (P4 per Quark). Waits until cimas + CI repoint is stable and opoudjis is comfortable.
- `basicdoc-models` + `metanorma-requirements-models` still standalone (kept as submodules per Quark's P1/P2 decision).
- `mn-samples-plateau-cg3` FL workflow (unrelated; @strogonoff's active debug work).

## Cross-references

- Parent design ticket: [metanorma-core#16](https://github.com/metanorma/metanorma-core/issues/16) (P1/P2/P3/P4 scope).
- P1/P2 landed at [metanorma/standoc-models](https://github.com/metanorma/standoc-models) (repo cut, monorepo layout, per-flavor git history preserved via `git filter-repo --to-subdirectory-filter`).

🤖
