### PR TITLE
actions-audit: quarterly cron workflow surfacing deprecated GHA pins (implements ci#377)

### DIFF
--- a/.github/deprecated-actions.yml
+++ b/.github/deprecated-actions.yml
@@ -1,0 +1,47 @@
+# Hand-curated deprecated GitHub Actions version list, consumed by
+# .github/workflows/actions-audit.yml (metanorma/ci#377). Updated
+# manually as deprecations are announced.
+#
+# Schema per entry:
+#   action: <owner>/<action-name>
+#   deprecated_versions: [v1, v2, ...]      # versions to flag as deprecated
+#   current_version: <ver>                  # suggested replacement (optional)
+#   notes: "..."                            # short human-readable rationale (optional)
+#   reference: "https://..."                # link to deprecation announcement (optional)
+
+- action: actions/upload-artifact
+  deprecated_versions: [v1, v2, v3]
+  current_version: v4
+  notes: "v3 deprecation announced 2024-Q4; surfaced fleet-wide by ci#374 sweep 2026-07-27."
+  reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
+
+- action: actions/download-artifact
+  deprecated_versions: [v1, v2, v3]
+  current_version: v4
+  notes: "Deprecated alongside upload-artifact@v3."
+  reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
+
+- action: actions/checkout
+  deprecated_versions: [v1, v2, v3]
+  current_version: v6
+  notes: "v3 uses Node16 (deprecated). v4/v5/v6 in current use across the stack."
+
+- action: actions/setup-node
+  deprecated_versions: [v1, v2, v3]
+  current_version: v4
+  notes: "Node16-based majors deprecated; v4 uses Node20."
+
+- action: actions/cache
+  deprecated_versions: [v1, v2, v3]
+  current_version: v4
+  notes: "v3 deprecated alongside other Node16-based actions."
+
+- action: actions/setup-python
+  deprecated_versions: [v1, v2, v3, v4]
+  current_version: v5
+  notes: "v4 and earlier use Node16 or older."
+
+- action: actions/setup-java
+  deprecated_versions: [v1, v2, v3]
+  current_version: v4
+  notes: "v3 uses Node16."

--- a/.github/scripts/audit-actions.rb
+++ b/.github/scripts/audit-actions.rb
@@ -1,0 +1,162 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# audit-actions.rb
+#
+# Scans metanorma/ci workflows + cimas-config templates for GitHub Actions
+# pins (uses: <owner>/<action>@<ver>), compares against a hand-curated
+# deprecated-actions.yml list, and creates a GitHub issue per finding.
+#
+# Surface-only: does not auto-bump pins or open PRs.
+# Idempotent: skips issue creation if an open issue with the same title
+# already exists (safe to re-run quarterly).
+#
+# Design: metanorma/ci#377. Ronald-approved 2026-08-07.
+#
+# Usage:
+#   ruby .github/scripts/audit-actions.rb            # real run (creates issues)
+#   ruby .github/scripts/audit-actions.rb --dry-run  # local test (no writes)
+
+require "yaml"
+require "open3"
+require "json"
+
+DRY_RUN = ARGV.include?("--dry-run")
+
+DEPRECATED_PATH = ".github/deprecated-actions.yml"
+SCAN_PATHS = [
+  ".github/workflows",
+  "cimas-config/gh-actions",
+].freeze
+
+REPO = ENV.fetch("GITHUB_REPOSITORY", "metanorma/ci")
+
+# Extract "uses: <owner>/<action>@<ver>" from all YAML files under SCAN_PATHS.
+# Returns Array of Hash { file:, line:, action:, version: }.
+def extract_pins(paths)
+  findings = []
+  paths.each do |root|
+    next unless Dir.exist?(root)
+    Dir.glob(File.join(root, "**", "*.{yml,yaml,erb}")).each do |file|
+      # Force UTF-8 encoding on read — some cimas-config templates contain
+      # non-ASCII bytes (comments, examples) that trip the default US-ASCII
+      # regex-match on macOS. Silently skip binary-looking lines.
+      raw = File.read(file, encoding: "UTF-8")
+      raw.each_line.with_index do |line, i|
+        line = line.chomp
+        next unless line.valid_encoding?
+        m = line.match(%r{^\s*uses:\s*([\w.-]+/[\w.-]+(?:/[\w.-]+)*)\s*@\s*(\S+)\s*$})
+        next unless m
+        action, version = m[1], m[2]
+        # Skip local reusable-workflow refs (./.github/workflows/...).
+        next if action.start_with?("./")
+        findings << { file: file, line: i + 1, action: action, version: version }
+      end
+    end
+  end
+  findings
+end
+
+# Check pin against deprecation list. Returns nil if not deprecated,
+# else the deprecation record.
+def check_deprecated(pin, deprecated_list)
+  deprecated_list.each do |entry|
+    next unless entry["action"] == pin[:action]
+    versions = Array(entry["deprecated_versions"])
+    return entry if versions.include?(pin[:version])
+  end
+  nil
+end
+
+def existing_audit_issue_titles
+  out, _err, status = Open3.capture3(
+    "gh", "issue", "list",
+    "--repo", REPO,
+    "--state", "open",
+    "--label", "actions-audit",
+    "--json", "title",
+    "--limit", "100",
+  )
+  return [] unless status.success?
+  JSON.parse(out).map { |i| i["title"] }
+rescue StandardError => e
+  warn "[actions-audit] issue-list query failed: #{e.class}: #{e.message}"
+  []
+end
+
+def create_issue(title, body)
+  cmd = ["gh", "issue", "create",
+         "--repo", REPO,
+         "--title", title,
+         "--body", body,
+         "--label", "actions-audit"]
+  system(*cmd)
+end
+
+# --- main ---
+
+unless File.exist?(DEPRECATED_PATH)
+  warn "[actions-audit] no deprecation list at #{DEPRECATED_PATH}; nothing to compare"
+  exit 0
+end
+
+deprecated_list = YAML.load_file(DEPRECATED_PATH) || []
+if deprecated_list.empty?
+  warn "[actions-audit] deprecation list is empty; nothing to check"
+  exit 0
+end
+
+pins = extract_pins(SCAN_PATHS)
+puts "[actions-audit] scanned #{pins.count} action pins across #{SCAN_PATHS.join(', ')}"
+
+findings = pins.filter_map do |pin|
+  record = check_deprecated(pin, deprecated_list)
+  next unless record
+  pin.merge(deprecation: record)
+end
+
+if findings.empty?
+  puts "[actions-audit] no deprecated pins found."
+  exit 0
+end
+
+puts "[actions-audit] #{findings.count} deprecated-pin instance(s) found."
+
+# Group by (action, version) for issue-per-class shape.
+by_class = findings.group_by { |f| [f[:action], f[:version]] }
+
+existing = DRY_RUN ? [] : existing_audit_issue_titles
+
+by_class.each do |(action, version), instances|
+  title = "[actions-audit] Deprecated pin: #{action}@#{version} in #{instances.size} file(s)"
+  if existing.include?(title)
+    puts "[actions-audit] skipping existing open issue: #{title}"
+    next
+  end
+
+  dep = instances.first[:deprecation]
+  body = +"## Deprecated action pin surfaced\n\n"
+  body << "- **Action**: `#{action}`\n"
+  body << "- **Deprecated version pinned**: `#{version}`\n"
+  body << "- **Suggested current version**: `#{dep['current_version']}`\n" if dep["current_version"]
+  body << "- **Notes**: #{dep['notes']}\n" if dep["notes"]
+  body << "- **Reference**: #{dep['reference']}\n" if dep["reference"]
+  body << "\n## Files affected (#{instances.size})\n\n"
+  instances.each do |f|
+    body << "- `#{f[:file]}`:#{f[:line]}\n"
+  end
+  body << "\n---\n\n"
+  body << "Surfaced by `.github/workflows/actions-audit.yml` (metanorma/ci#377). "
+  body << "Surface-only; no auto-bump. Fix: bump the pin in each file, "
+  body << "verify the reusable/template still works, then close this issue.\n\n"
+  body << "🤖\n"
+
+  if DRY_RUN
+    puts "[dry-run] would create issue:"
+    puts "  title: #{title}"
+    puts "  body preview:\n#{body.lines.first(6).join('    ')}"
+  else
+    puts "[actions-audit] creating issue: #{title}"
+    create_issue(title, body)
+  end
+end

--- a/.github/workflows/actions-audit.yml
+++ b/.github/workflows/actions-audit.yml
@@ -1,0 +1,32 @@
+name: actions-audit
+
+# Quarterly audit of GitHub Actions pins in metanorma/ci reusables +
+# cimas-config templates. Surfaces deprecated pins as issues on this
+# repo. Surface-only — no auto-bump PRs. Design: metanorma/ci#377.
+
+on:
+  schedule:
+    # 1st Monday of Feb/May/Aug/Nov at 08:00 UTC — quarterly cadence
+    # right-sized to GitHub's typical 6+ month deprecation window.
+    - cron: '0 8 1-7 2,5,8,11 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: false
+
+      - name: Run audit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ruby .github/scripts/audit-actions.rb


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/377.

## Summary

Implements ci#377 (Ronald-approved 2026-08-07): quarterly cron workflow that scans metanorma/ci reusables + cimas-config templates for deprecated GitHub Actions pins, surfaces findings as issues on this repo. Surface-only — no auto-bump PRs.

## What lands

1. `.github/workflows/actions-audit.yml` — cron trigger (1st Monday of Feb/May/Aug/Nov at 08:00 UTC) + `workflow_dispatch` for manual runs.
2. `.github/scripts/audit-actions.rb` — Ruby script: scans YAML files under `.github/workflows/` + `cimas-config/gh-actions/`, extracts `uses: <owner>/<action>@<ver>` pins, checks against the hand-curated deprecation list, creates issues per (action, version) class. Skips issue creation if an open issue with the same title already exists (idempotent across quarterly runs). Supports `--dry-run` for local testing.
3. `.github/deprecated-actions.yml` — seed hand-curated list: `actions/upload-artifact@v1-3`, `download-artifact@v1-3`, `checkout@v1-3`, `setup-node@v1-3`, `cache@v1-3`, `setup-python@v1-4`, `setup-java@v1-3`. Grows as new deprecations are announced.

## Design constraints (per Ronald's ci#377 approval)

- **Quarterly cadence** right-sized to GitHub's typical 6+ month deprecation window (two-quarter lead time).
- **Scope**: `metanorma/ci` reusables + cimas TEMPLATEs. Post-cimas#68 Phase 2 conversion, scope shrinks to reusables + remaining cimas-managed config classes; consumer-owned stubs are out of scope (maintainer responsibility).
- **Surface only** — no auto-bump PRs. Dependabot on metanorma/ci is a separate decision.
- **Issue creation on finding** — findings land on maintainer dashboard rather than requiring workflow-log review.
- **Hand-curated deprecation list** for v1 (GitHub has no stable machine-readable deprecation API for actions majors).

## Test plan

- [x] `ruby .github/scripts/audit-actions.rb --dry-run` locally on the ci sibling clone — verified extract + check + would-create-issue flow.
- [ ] CI: `workflow_dispatch` fire post-merge to verify real-run creates issues correctly for whatever's currently deprecated in the ci tree.
- [ ] Quarterly cron: first fire next 1st-Monday-of-quarter after merge.

## Follow-ups (separate)

- Extend `deprecated-actions.yml` as new deprecations are announced. Suggest tracking additions as a rolling issue rather than PRs per addition.
- Dependabot on metanorma/ci decision (referenced in ci#377): separate ticket.
- Consumer-stub scope: applies after cimas#68 Phase 2 (per Ronald's constraint).

🤖
